### PR TITLE
initial helm yaml to stand up service in dev

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,11 @@ configurations {
 }
 
 dependencies {
+  // Spring boot dependencies
   implementation("org.springframework.boot:spring-boot-starter-webflux")
+
+  // OpenAPI
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
 }
 
 kotlin {

--- a/helm_deploy/hmpps-challenge-support-intervention-plan-api/values.yaml
+++ b/helm_deploy/hmpps-challenge-support-intervention-plan-api/values.yaml
@@ -21,6 +21,9 @@ generic-service:
     SPRING_PROFILES_ACTIVE: "logstash"
     APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY)"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
+    DB_SSL_MODE: "verify-full"
+    AWS_REGION: "eu-west-2"
+    HMPPS_SQS_USE_WEB_TOKEN: "true"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:
@@ -30,6 +33,12 @@ generic-service:
   namespace_secrets:
     hmpps-challenge-support-intervention-plan-api:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
+    rds-postgresql-instance-output:
+      DB_SERVER: "rds_instance_address"
+      DB_NAME: "database_name"
+      DB_USER: "database_username"
+      DB_PASS: "database_password"
+      HMPPS_SQS_TOPICS_HMPPSEVENTTOPIC_ARN: "topic_arn"
 
   allowlist:
     groups:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -5,10 +5,15 @@ generic-service:
   replicaCount: 2
 
   ingress:
-    host: hmpps-challenge-support-intervention-plan-api-dev.hmpps.service.justice.gov.uk
+    host: csip-api-dev.hmpps.service.justice.gov.uk
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
+    SPRING_PROFILES_ACTIVE: dev
+    API_BASE_URL_HMPPS_AUTH: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
+    API_BASE_URL_MANAGE_USERS: "https://manage-users-api-dev.hmpps.service.justice.gov.uk"
+    EVENTS_BASE_URL: "https://csip-api-dev.hmpps.service.justice.gov.uk"
+    SERVICE_ACTIVE_PRISONS: "LEI"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -5,7 +5,7 @@ generic-service:
   replicaCount: 2
 
   ingress:
-    host: hmpps-challenge-support-intervention-plan-api-preprod.hmpps.service.justice.gov.uk
+    host: csip-api-preprod.hmpps.service.justice.gov.uk
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -3,7 +3,7 @@
 
 generic-service:
   ingress:
-    host: hmpps-challenge-support-intervention-plan-api.hmpps.service.justice.gov.uk
+    host: csip-api.hmpps.service.justice.gov.uk
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts


### PR DESCRIPTION
This PR aims at making the dev deployment available at the expected host `csip-api-dev.hmpps.service.justice.gov.uk` with https://csip-api-dev.hmpps.service.justice.gov.uk/swagger-ui/index.html being accessible