### PR TITLE
MIC-111B remediation on Create CSIP and Referral

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/entity/CsipRecord.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/entity/CsipRecord.kt
@@ -179,7 +179,7 @@ data class CsipRecord(
       reason = reason,
       activeCaseLoadId = csipRequestContext.activeCaseLoadId,
       isRecordAffected = true,
-      isReferralAffected = referral != null,
+      isReferralAffected = true,
       isContributoryFactorAffected = referral!!.contributoryFactors().isNotEmpty(),
     )
     registerEntityEvent(
@@ -192,7 +192,7 @@ data class CsipRecord(
         reason = reason,
         createdBy = createdBy,
         isRecordAffected = true,
-        isReferralAffected = referral != null,
+        isReferralAffected = true,
         isContributoryFactorAffected = referral!!.contributoryFactors().isNotEmpty(),
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/exception/InvalidReferenceDataCodeException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/exception/InvalidReferenceDataCodeException.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.exception
+
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.enumeration.ReferenceDataType
+
+enum class InvalidReferenceCodeType(val message: String) {
+  DOES_NOT_EXIST("does not exist"),
+  IS_INACTIVE("is inactive"),
+}
+
+class InvalidReferenceDataCodeException(
+  val type: InvalidReferenceCodeType,
+  val domain: ReferenceDataType,
+  val code: String,
+) : Exception() {
+  companion object {
+    fun combineToIllegalArgumentException(exceptions: Collection<InvalidReferenceDataCodeException>) {
+      throw exceptions.toIllegalArgumentException()
+    }
+  }
+
+  fun toIllegalArgumentException() = IllegalArgumentException(
+    "$domain code '$code' ${type.message}",
+  )
+}
+
+fun Collection<InvalidReferenceDataCodeException>.toIllegalArgumentException() = let { exceptions ->
+  if (exceptions.size == 1) {
+    return exceptions.single().toIllegalArgumentException()
+  }
+
+  this.groupBy { it.domain }.map { byDomain ->
+    byDomain.value.groupBy { it.type }.map { byType ->
+      byType.value.joinToString(", ") { "'${it.code}'" }.let {
+        "${byDomain.key} code(s) $it ${byType.key.message}"
+      }
+    }.joinToString(". ")
+  }.joinToString(". ").let { IllegalArgumentException(it) }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/InvestigationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/InvestigationService.kt
@@ -6,14 +6,18 @@ import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.con
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.domain.toCsipRecordEntity
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.domain.toModel
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.entity.ReferenceData
-import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.enumeration.ReferenceDataType
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.enumeration.ReferenceDataType.INTERVIEWEE_ROLE
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.exception.CsipRecordNotFoundException
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.exception.InvalidReferenceCodeType.DOES_NOT_EXIST
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.exception.InvalidReferenceCodeType.IS_INACTIVE
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.exception.InvalidReferenceDataCodeException
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.exception.MissingReferralException
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.Investigation
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.request.CreateInterviewRequest
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.request.CreateInvestigationRequest
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.repository.CsipRecordRepository
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.repository.ReferenceDataRepository
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.utils.associateByAndHandleException
 import java.util.UUID
 
 @Service
@@ -28,8 +32,12 @@ class InvestigationService(
     context: CsipRequestContext,
   ): Investigation {
     val intervieweeRoleMap: Map<String, ReferenceData> = request.interviews?.let { interviews ->
-      val roles = referenceDataRepository.findByDomain(ReferenceDataType.INTERVIEWEE_ROLE)
-      interviews.associateBy({ it.intervieweeRoleCode }, { it.getInterviewRole(roles) })
+      val roles = referenceDataRepository.findByDomain(INTERVIEWEE_ROLE)
+      interviews.associateByAndHandleException(
+        { it.intervieweeRoleCode },
+        { it.getInterviewRole(roles) },
+        InvalidReferenceDataCodeException::combineToIllegalArgumentException,
+      )
     } ?: emptyMap()
 
     return csipRecordRepository.findByRecordUuid(recordUuid)?.let {
@@ -51,7 +59,7 @@ class InvestigationService(
 
   private fun CreateInterviewRequest.getInterviewRole(roles: Collection<ReferenceData>): ReferenceData {
     return roles.find { it.code.equals(intervieweeRoleCode) }?.also {
-      require(it.isActive()) { "INTERVIEWEE_ROLE code '$intervieweeRoleCode' is inactive" }
-    } ?: throw IllegalArgumentException("INTERVIEWEE_ROLE code '$intervieweeRoleCode' does not exist")
+      if (!it.isActive()) throw InvalidReferenceDataCodeException(IS_INACTIVE, INTERVIEWEE_ROLE, intervieweeRoleCode)
+    } ?: throw InvalidReferenceDataCodeException(DOES_NOT_EXIST, INTERVIEWEE_ROLE, intervieweeRoleCode)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/SaferCustodyScreeningOutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/SaferCustodyScreeningOutcomeService.kt
@@ -25,7 +25,7 @@ class SaferCustodyScreeningOutcomeService(
     request: CreateSaferCustodyScreeningOutcomeRequest,
     context: CsipRequestContext,
   ): SaferCustodyScreeningOutcome {
-    val outcomeType = getOutcomeType(request.outcomeTypeCode)
+    val outcomeType = referenceDataRepository.getOutcomeType(request.outcomeTypeCode)
 
     return csipRecordRepository.findByRecordUuid(recordUuid)?.let {
       it.referral?.let { referral ->
@@ -44,8 +44,8 @@ class SaferCustodyScreeningOutcomeService(
     } ?: throw CsipRecordNotFoundException("Could not find CSIP record with UUID $recordUuid")
   }
 
-  private fun getOutcomeType(code: String) =
-    referenceDataRepository.findByDomainAndCode(ReferenceDataType.OUTCOME_TYPE, code)?.also {
+  private fun ReferenceDataRepository.getOutcomeType(code: String) =
+    findByDomainAndCode(ReferenceDataType.OUTCOME_TYPE, code)?.also {
       require(it.isActive()) { "OUTCOME_TYPE code '$code' is inactive" }
     } ?: throw IllegalArgumentException("OUTCOME_TYPE code '$code' does not exist")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/utils/InlineFuncUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/utils/InlineFuncUtils.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.utils
+
+inline fun <T, K, V, reified E : Exception> Iterable<T>.associateByAndHandleException(
+  keySelector: (T) -> K,
+  valueTransform: (T) -> V,
+  exceptionsHandler: (Collection<E>) -> Unit,
+): Map<K, V> {
+  val destination = HashMap<K, V>()
+  val exceptions = ArrayList<E>()
+  for (element in this) {
+    try {
+      destination[keySelector(element)] = valueTransform(element)
+    } catch (e: Exception) {
+      if (e is E) {
+        exceptions.add(e)
+      } else {
+        throw e
+      }
+    }
+  }
+
+  if (exceptions.isNotEmpty()) {
+    exceptionsHandler(exceptions)
+  }
+
+  return destination
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/resource/CreateCsipRecordsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/resource/CreateCsipRecordsIntTest.kt
@@ -279,13 +279,37 @@ class CreateCsipRecordsIntTest(
   }
 
   @Test
+  fun `400 bad request - multiple contributory factor not found`() {
+    val request = createCsipRecordRequest(
+      incidentTypeCode = "ATO",
+      incidentLocationCode = "EDU",
+      refererAreaCode = "ACT",
+      incidentInvolvementCode = "OTH",
+      contributoryFactorTypeCode = listOf("D", "E", "F"),
+    )
+
+    val response = webTestClient.createCsipResponseSpec(request = request, prisonNumber = PRISON_NUMBER)
+      .expectStatus().isBadRequest
+      .expectBody(ErrorResponse::class.java)
+      .returnResult().responseBody
+
+    with(response!!) {
+      assertThat(status).isEqualTo(400)
+      assertThat(errorCode).isNull()
+      assertThat(userMessage).isEqualTo("Validation failure: CONTRIBUTORY_FACTOR_TYPE code(s) 'D', 'E', 'F' does not exist")
+      assertThat(developerMessage).isEqualTo("CONTRIBUTORY_FACTOR_TYPE code(s) 'D', 'E', 'F' does not exist")
+      assertThat(moreInfo).isNull()
+    }
+  }
+
+  @Test
   fun `201 created - CSIP record created via DPS`() {
     val request = createCsipRecordRequest(
       incidentTypeCode = "ATO",
       incidentLocationCode = "EDU",
       refererAreaCode = "ACT",
       incidentInvolvementCode = "OTH",
-      contributoryFactorTypeCode = "AFL",
+      contributoryFactorTypeCode = listOf("AFL"),
     )
 
     val response = webTestClient.createCsipResponseSpec(request = request, prisonNumber = PRISON_NUMBER, source = DPS)
@@ -374,7 +398,7 @@ class CreateCsipRecordsIntTest(
       incidentLocationCode = "EDU",
       refererAreaCode = "ACT",
       incidentInvolvementCode = "OTH",
-      contributoryFactorTypeCode = "AFL",
+      contributoryFactorTypeCode = listOf("AFL"),
     )
 
     val response = webTestClient.createCsipResponseSpec(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/utils/TestConstants.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/utils/TestConstants.kt
@@ -23,7 +23,7 @@ fun createCsipRecordRequest(
   incidentLocationCode: String = "B",
   refererAreaCode: String = "C",
   incidentInvolvementCode: String = "D",
-  contributoryFactorTypeCode: String = "D",
+  contributoryFactorTypeCode: Collection<String> = listOf("D"),
 ) =
   CreateCsipRecordRequest(
     LOG_NUMBER,
@@ -41,7 +41,7 @@ fun createReferralRequest(
   incidentLocationCode: String = "B",
   refererAreaCode: String = "C",
   incidentInvolvementCode: String = "D",
-  contributoryFactorTypeCode: String = "D",
+  contributoryFactorTypeCode: Collection<String> = listOf("D"),
 ) =
   CreateReferralRequest(
     LocalDate.now(),
@@ -60,7 +60,7 @@ fun createReferralRequest(
     "",
     false,
     null,
-    listOf(createContributoryFactorRequest(contributoryFactorTypeCode)),
+    contributoryFactorTypeCode.map { createContributoryFactorRequest(it) },
   )
 
 fun referral(csipRecord: CsipRecord = csipRecord()) =


### PR DESCRIPTION
1. hardcoding isReferralAffected=true for relevant audit event / domain event
2. annotating `CsipRecordService` class to be Transactional
3. enhance error message when multiple Contributory Factor Type codes are inactive or not found