### PR TITLE
Fix interviewee role ordering and deactivate ACC ref code

### DIFF
--- a/src/main/resources/migration/common/V34__update_ref_data.sql
+++ b/src/main/resources/migration/common/V34__update_ref_data.sql
@@ -1,0 +1,24 @@
+update reference_data
+set list_sequence = 99
+where domain = 'INTERVIEWEE_ROLE'
+  and code = 'OTHER';
+
+update reference_data
+set list_sequence = 10
+where domain = 'INTERVIEWEE_ROLE'
+  and code = 'PERP';
+
+update reference_data
+set list_sequence = 20
+where domain = 'INTERVIEWEE_ROLE'
+  and code = 'VICTIM';
+
+update reference_data
+set list_sequence = 30
+where domain = 'INTERVIEWEE_ROLE'
+  and code = 'WITNESS';
+
+update reference_data
+set deactivated_at = '2024-08-29 00:00:00', deactivated_by = 'MOVE_AND_IMPROVE_TEAM'
+where domain = 'SCREENING_OUTCOME_TYPE'
+  and code = 'ACC';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/resource/ReferenceDataTranslationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/resource/ReferenceDataTranslationIntTest.kt
@@ -24,8 +24,7 @@ class ReferenceDataTranslationIntTest : IntegrationTestBase() {
     assertThat(referenceData[0].code).isEqualTo("CUR")
     assertThat(referenceData[1].code).isEqualTo("OPE")
     assertThat(referenceData[2].code).isEqualTo("WIN")
-    assertThat(referenceData[3].code).isEqualTo("ACC")
-    assertThat(referenceData[4].code).isEqualTo("NFA")
+    assertThat(referenceData[3].code).isEqualTo("NFA")
   }
 
   private fun WebTestClient.getReferenceData(


### PR DESCRIPTION
MIC-483
The order of the involvement should change.
options for “How was the interviewee involved?” read: Perpetrator, Victim, Witness, Other. 

MIC-481
On Screen a Referral, there is not an option to “Support through ACCT”
On Make a CSIP Decision, there is not an option to “Support through ACCT” 

* DECISION_OUTCOME_TYPE already has ACCT deactivated, so in this PR we only deactivate ACCT for Screening Outcome Type