### PR TITLE
Rename delete endpoint for sync

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/sync/SyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/sync/SyncController.kt
@@ -148,7 +148,7 @@ class SyncController(private val csip: SyncCsipRecord, private val retry: RetryT
   @DeleteMapping("/{id}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @PreAuthorize("hasAnyRole('$ROLE_NOMIS')")
-  fun deleteCsipRecord(@PathVariable id: UUID, @RequestBody request: DefaultLegacyActioned) {
+  fun deleteRecord(@PathVariable id: UUID, @RequestBody request: DefaultLegacyActioned) {
     setSyncContext(request)
     csip.deleteCsipRecord(id)
   }


### PR DESCRIPTION
PR renames delete endpoint for sync to prevent generated naming of `deleteCsipRecord_1` in swagger docs