### PR TITLE
MIAD-444 use new queue for domain events

### DIFF
--- a/helm_deploy/hmpps-challenge-support-intervention-plan-api/values.yaml
+++ b/helm_deploy/hmpps-challenge-support-intervention-plan-api/values.yaml
@@ -65,9 +65,9 @@ generic-service:
       DB_PASS: "database_password"
     hmpps-domain-events-topic:
       HMPPS_SQS_TOPICS_HMPPSEVENTTOPIC_ARN: "topic_arn"
-    sqs-domain-events-secret:
+    domain-events-queue-secret:
       HMPPS_SQS_QUEUES_HMPPSDOMAINEVENTSQUEUE_QUEUE_NAME: "queue_name"
-    sqs-domain-events-dlq-secret:
+    domain-events-dlq-secret:
       HMPPS_SQS_QUEUES_HMPPSDOMAINEVENTSQUEUE_DLQ_NAME: "queue_name"
 
   allowlist:


### PR DESCRIPTION
There are 3 PRs for CP environment to create new queues with a more generic name, not linked to the team name. This will enable the team name to change on handover at some point in the future without risk of losing messages.

https://github.com/ministryofjustice/cloud-platform-environments/pull/30077
https://github.com/ministryofjustice/cloud-platform-environments/pull/30079
https://github.com/ministryofjustice/cloud-platform-environments/pull/30080