### PR TITLE
LSM-276/CSIP-API-Prometheus-dependency-update

### DIFF
--- a/helm_deploy/hmpps-challenge-support-intervention-plan-api/Chart.yaml
+++ b/helm_deploy/hmpps-challenge-support-intervention-plan-api/Chart.yaml
@@ -8,5 +8,5 @@ dependencies:
     version: "3.12"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: "1.14"
+    version: "1.16"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
updated generic-prometheus-alerts dependency 1.14 to 1.16