### PR TITLE
Remove pinned PG driver version as SB now includes the fixed version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
   // Database dependencies
   runtimeOnly("org.springframework.boot:spring-boot-starter-flyway")
   runtimeOnly("org.flywaydb:flyway-database-postgresql")
-  runtimeOnly("org.postgresql:postgresql:42.7.10")
+  runtimeOnly("org.postgresql:postgresql")
 
   // Test dependencies
   testImplementation("org.testcontainers:postgresql:1.21.4")


### PR DESCRIPTION
Spring Boot 4 now includes 42.7.10 which reverts the inconsistent dates caused by https://github.com/pgjdbc/pgjdbc/pull/3932 in 42.7.9