### PR TITLE
All fixable vulnerabilities addressed

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,14 +2,18 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_25
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.5.1"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.5.7"
   kotlin("plugin.spring") version "2.4.0"
   kotlin("plugin.jpa") version "2.4.0"
   jacoco
 }
 
 ext["jackson-bom.version"] = "3.2.0"
-ext["jackson-2-bom.version"] = "2.22.0"
+ext["jackson-2-bom.version"] = "2.22.1"
+ext["logback.version"] = "1.5.36"
+ext["tomcat.version"] = "11.0.23"
+ext["postgresql.version"] = "42.7.12"
+ext["httpcore5.version"] = "5.4.3"
 
 configurations {
   testImplementation { exclude(group = "org.junit.vintage") }
@@ -43,6 +47,12 @@ dependencies {
   testImplementation("org.springframework.boot:spring-boot-starter-webflux-test")
   testImplementation("org.wiremock:wiremock-standalone:3.13.2")
   testImplementation("org.awaitility:awaitility-kotlin:4.3.0")
+
+  constraints {
+    implementation("io.opentelemetry:opentelemetry-api:1.62.0") {
+      because("CVE-2026-45292 - remove when transitive dependency is updated")
+    }
+  }
 }
 
 kotlin {


### PR DESCRIPTION

### Changes made

- Plugin bump: uk.gov.justice.hmpps.gradle-spring-boot 10.5.1 → 10.5.7 (brings Spring Boot 4.0.7)
- logback-core → 1.5.36 via ext["logback.version"] (CVE-2026-13006, HIGH)
- tomcat-embed-core → 11.0.23 via ext["tomcat.version"] (CVE-2026-55955, CVE-2026-53434 HIGH; CVE-2026-55956, CVE-2026-55276, CVE-2026-53404 MEDIUM)
- postgresql → 42.7.12 via ext["postgresql.version"] (CVE-2026-54291, HIGH)
- httpcore5-h2 → 5.4.3 via ext["httpcore5.version"] (CVE-2026-54428, CVE-2026-54399, HIGH)
- opentelemetry-api → 1.62.0 via dependency constraint (CVE-2026-45292, HIGH)
- jackson-databind → 2.22.1 via ext["jackson-2-bom.version"] (CVE-2026-54515, MEDIUM)