### PR TITLE
JDA-400 Create JDA client abstraction

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -13,6 +13,7 @@ generic-service:
     API_BASE_URL_HMPPS_AUTH: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     API_BASE_URL_MANAGE_USERS: "https://manage-users-api-dev.hmpps.service.justice.gov.uk"
     API_BASE_URL_CASENOTES: "https://dev.offender-case-notes.service.justice.gov.uk"
+    API_BASE_URL_JDA: "https://justice-data-agent-client-api-dev.hmpps.service.justice.gov.uk"
     API_BASE_URL_PRISONER_SEARCH: "https://prisoner-search-dev.prison.service.justice.gov.uk"
     SERVICE_BASE_URL: "https://csip-api-dev.hmpps.service.justice.gov.uk"
     SERVICE_ACTIVE_PRISONS: "***"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -13,6 +13,7 @@ generic-service:
     API_BASE_URL_HMPPS_AUTH: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
     API_BASE_URL_MANAGE_USERS: "https://manage-users-api-preprod.hmpps.service.justice.gov.uk"
     API_BASE_URL_CASENOTES: "https://preprod.offender-case-notes.service.justice.gov.uk"
+    API_BASE_URL_JDA: "https://justice-data-agent-client-api-preprod.hmpps.service.justice.gov.uk/"
     API_BASE_URL_PRISONER_SEARCH: "https://prisoner-search-preprod.prison.service.justice.gov.uk"
     SERVICE_BASE_URL: "https://csip-api-preprod.hmpps.service.justice.gov.uk"
     SERVICE_ACTIVE_PRISONS: "***"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -10,6 +10,7 @@ generic-service:
     API_BASE_URL_HMPPS_AUTH: "https://sign-in.hmpps.service.justice.gov.uk/auth"
     API_BASE_URL_MANAGE_USERS: "https://manage-users-api.hmpps.service.justice.gov.uk"
     API_BASE_URL_CASENOTES: "https://offender-case-notes.service.justice.gov.uk"
+    API_BASE_URL_JDA: " https://justice-data-agent-client-api.hmpps.service.justice.gov.uk/"
     API_BASE_URL_PRISONER_SEARCH: "https://prisoner-search.prison.service.justice.gov.uk"
     SERVICE_BASE_URL: "https://csip-api.hmpps.service.justice.gov.uk"
     SERVICE_ACTIVE_PRISONS: "***"

--- a/run-local.sh
+++ b/run-local.sh
@@ -31,6 +31,7 @@ export PRISONER_SEARCH_CLIENT_SECRET="$HMPPS_CSIP_PRISONER_SEARCH_CLIENT_SECRET"
 export API_BASE_URL_HMPPS_AUTH=https://sign-in-dev.hmpps.service.justice.gov.uk/auth
 export API_BASE_URL_MANAGE_USERS=https://manage-users-api-dev.hmpps.service.justice.gov.uk
 export API_BASE_URL_CASENOTES=https://dev.offender-case-notes.service.justice.gov.uk
+export API_BASE_URL_JDA=https://justice-data-agent-client-api-dev.hmpps.service.justice.gov.uk
 export API_BASE_URL_PRISONER_SEARCH=https://prisoner-search-dev.prison.service.justice.gov.uk
 
 # Run the application with local profiles active

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/client/jda/JdaClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/client/jda/JdaClient.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.client.jda
+
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaRequest
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaRequestResponse
+
+@Component
+class JdaClient(
+  @Qualifier("jdaWebClient")
+  private val webClient: WebClient,
+) {
+
+  fun <T> submitRequest(
+    request: JdaRequest<T>,
+  ): JdaRequestResponse = TODO("Implemented in JDA-361")
+
+  fun <T> queueRequest(
+    request: JdaRequest<T>,
+  ): JdaRequestResponse = TODO("Future asynchronous JDA integration")
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/config/WebClientConfiguration.kt
@@ -15,6 +15,7 @@ class WebClientConfiguration(
   @Value("\${api.base.url.manage-users}") private val manageUsersBaseUri: String,
   @Value("\${api.base.url.prisoner-search}") private val prisonerSearchBaseUri: String,
   @Value("\${api.base.url.casenotes}") private val casenotesBaseUri: String,
+  @Value("\${api.base.url.jda}") private val jdaBaseUri: String,
   @Value("\${api.health-timeout:2s}") val healthTimeout: Duration,
   @Value("\${api.timeout:2s}") val timeout: Duration,
 ) {
@@ -35,4 +36,7 @@ class WebClientConfiguration(
 
   @Bean
   fun caseNotesWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: WebClient.Builder) = builder.authorisedWebClient(authorizedClientManager, "manage-users-api", casenotesBaseUri, timeout)
+
+  @Bean
+  fun jdaWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: WebClient.Builder) = builder.authorisedWebClient(authorizedClientManager, "manage-users-api", jdaBaseUri, timeout)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaError.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaError.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda
+
+data class JdaError(
+  val code: String,
+  val message: String,
+  val stage: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaErrorResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaErrorResponse.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda
+
+data class JdaErrorResponse(
+  val error: JdaError,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaRequestMetadata.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaRequestMetadata.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda
+
+import java.time.OffsetDateTime
+
+data class JdaRequestMetadata(
+  val requestType: JdaRequestType,
+  val submittedAt: OffsetDateTime,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaRequestResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaRequestResponse.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda
+
+import java.util.*
+
+data class JdaRequestResponse(
+  val requestId: UUID,
+  val correlationId: String,
+  val prompt: JdaPrompt,
+  val status: JdaRequestStatus,
+  val metadata: JdaRequestMetadata,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaRequestStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaRequestStatus.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda
+
+enum class JdaRequestStatus {
+  QUEUED,
+  PROCESSING,
+  SUCCEEDED,
+  FAILED,
+  REJECTED,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaRequestType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaRequestType.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda
+
+enum class JdaRequestType {
+  SYNC,
+  ASYNC,
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -21,6 +21,7 @@ api:
       manage-users: http://localhost:8111
       prisoner-search: http://localhost:8112
       casenotes: http://localhost:8113
+      jda: http://localhost:8114
 
 manage-users:
   client:


### PR DESCRIPTION
## JIRA

JDA-400

## Summary

Creates the Justice Data Agent (JDA) client that will act as the integration point between CSIP and the JDA platform.

This ticket establishes the client structure, configuration and request/response contracts only. No JDA API integration has been implemented as part of this work.

## Changes

### JDA Client

- Added `JdaClient`
- Added synchronous request submission entry point:
  - `submitRequest(...)`
- Added asynchronous request submission entry point:
  - `queueRequest(...)`
- Added placeholder implementations for follow-on tickets

### JDA Models

Added strongly typed JDA request response models:

- `JdaRequestResponse`
- `JdaRequestMetadata`
- `JdaRequestStatus`
- `JdaRequestType`
- `JdaError`
- `JdaErrorResponse`

### Configuration

- Added `jdaWebClient`
- Added `api.base.url.jda` configuration
- Added JDA configuration to:
  - `application-test.yml`
  - `run-local.sh`
  - deployment values files

### Design Notes

The JDA client follows the existing external client pattern already used within CSIP (e.g. `ManageUsersClient`, `PrisonerSearchClient` and `CaseNotesClient`).

The client currently exposes both synchronous and asynchronous submission operations supported by the JDA API. However, no HTTP submission logic has been implemented in this ticket.

## Out of Scope

The following will be delivered in subsequent tickets:

- JDA synchronous request submission implementation (`submitRequest`)
- Request/response handling
- Error handling
- Integration tests
- WireMock stubs
- JDA asynchronous processing implementation

## Follow-on Work

- JDA-361 - Implement synchronous request submission to JDA
- Future ticket - Implement asynchronous request submission support