### PR TITLE
JDA-361 Trigger CSIP Assist JDA analysis for investigation outcomes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaRequestStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaRequestStatus.kt
@@ -1,9 +1,20 @@
 package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 enum class JdaRequestStatus {
+  @JsonProperty("queued")
   QUEUED,
+
+  @JsonProperty("processing")
   PROCESSING,
+
+  @JsonProperty("succeeded")
   SUCCEEDED,
+
+  @JsonProperty("failed")
   FAILED,
+
+  @JsonProperty("rejected")
   REJECTED,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaRequestType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaRequestType.kt
@@ -1,6 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 enum class JdaRequestType {
+  @JsonProperty("sync")
   SYNC,
+
+  @JsonProperty("async")
   ASYNC,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/request/CaseNotesRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/request/CaseNotesRequest.kt
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Schema(description = "The request body for getting a case notes")
 data class CaseNotesLookupRequest(
   val offenderIdentifier: String,
-  val includeSensitive: Boolean = false,
+  val includeSensitive: Boolean = true,
 )
 
 @Schema(description = "The query parameters for filtering case notes")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/request/CaseNotesRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/request/CaseNotesRequest.kt
@@ -6,8 +6,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class CaseNotesLookupRequest(
   val offenderIdentifier: String,
   val includeSensitive: Boolean = false,
-  val outcomeTypeCode: String,
-  val caseload: String,
 )
 
 @Schema(description = "The query parameters for filtering case notes")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNotesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNotesService.kt
@@ -1,12 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.service
 
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.client.casenotes.CaseNotesClient
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.client.casenotes.CaseNotesRequest
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.client.casenotes.CaseNotesResponse
-import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.config.CsipAssistConfig
-import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.constant.INVESTIGATION_REQUIRED
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.request.CaseNotesFilterParams
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.request.CaseNotesLookupRequest
 import java.time.Clock
@@ -15,14 +12,14 @@ import java.time.LocalDateTime
 @Service
 class CaseNotesService(
   private val caseNotesClient: CaseNotesClient,
-  private val csipAssistConfig: CsipAssistConfig,
-  @Value("\${feature.csip-assist}")
-  private val featureFlag: Boolean,
   private val clock: Clock,
 ) {
-  fun getCaseNotes(request: CaseNotesLookupRequest, params: CaseNotesFilterParams = CaseNotesFilterParams()): CaseNotesResponse? {
-    if (!featureFlag || request.outcomeTypeCode != INVESTIGATION_REQUIRED || !csipAssistConfig.isActivePrison(request.caseload)) return null
+  fun getCaseNotes(
+    request: CaseNotesLookupRequest,
+    params: CaseNotesFilterParams = CaseNotesFilterParams(),
+  ): CaseNotesResponse {
     val now = LocalDateTime.now(clock)
+
     return caseNotesClient.getCaseNotes(
       request.offenderIdentifier,
       CaseNotesRequest(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/JdaService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/JdaService.kt
@@ -21,15 +21,12 @@ class JdaService(
     prisonCode: String,
     correlationId: String,
   ) {
-    if (!featureFlag) return
-
-    if (!csipAssistConfig.isActivePrison(prisonCode)) return
+    if (!featureFlag || !csipAssistConfig.isActivePrison(prisonCode)) return
 
     val caseNotes =
       caseNotesService.getCaseNotes(
         CaseNotesLookupRequest(
           offenderIdentifier = offenderIdentifier,
-          includeSensitive = true,
         ),
       )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/JdaService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/JdaService.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.service
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.client.casenotes.toJdaRequest
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.client.jda.JdaClient
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.config.CsipAssistConfig
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.request.CaseNotesLookupRequest
+
+@Service
+class JdaService(
+  private val caseNotesService: CaseNotesService,
+  private val jdaClient: JdaClient,
+  private val csipAssistConfig: CsipAssistConfig,
+  @Value("\${feature.csip-assist}")
+  private val featureFlag: Boolean,
+) {
+
+  fun submitCaseNotesForAnalysis(
+    offenderIdentifier: String,
+    prisonCode: String,
+    correlationId: String,
+  ) {
+    if (!featureFlag) return
+
+    if (!csipAssistConfig.isActivePrison(prisonCode)) return
+
+    val caseNotes =
+      caseNotesService.getCaseNotes(
+        CaseNotesLookupRequest(
+          offenderIdentifier = offenderIdentifier,
+          includeSensitive = true,
+        ),
+      )
+
+    jdaClient.submitRequest(
+      caseNotes.toJdaRequest(correlationId),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/SaferCustodyScreeningOutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/SaferCustodyScreeningOutcomeService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.se
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.constant.INVESTIGATION_REQUIRED
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.domain.CsipRecordRepository
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.domain.referencedata.ReferenceDataRepository
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.domain.referencedata.getActiveReferenceData
@@ -20,6 +21,7 @@ import java.util.UUID
 class SaferCustodyScreeningOutcomeService(
   private val csipRecordRepository: CsipRecordRepository,
   private val referenceDataRepository: ReferenceDataRepository,
+  private val jdaService: JdaService,
 ) {
 
   @PublishCsipEvent(CSIP_UPDATED)
@@ -28,10 +30,32 @@ class SaferCustodyScreeningOutcomeService(
     request: UpsertSaferCustodyScreeningOutcomeRequest,
   ): SaferCustodyScreeningOutcome {
     val record = verifyCsipRecordExists(csipRecordRepository, recordUuid)
-    return with(verifyExists(record.referral) { MissingReferralException(recordUuid) }) {
-      val screening = this.saferCustodyScreeningOutcome
-      upsertSaferCustodyScreeningOutcome(request = request, referenceDataRepository::getActiveReferenceData).toModel()
-        .apply { new = screening == null }
+
+    val referral = verifyExists(record.referral) {
+      MissingReferralException(recordUuid)
     }
+
+    val result =
+      with(referral) {
+        val screening = saferCustodyScreeningOutcome
+
+        upsertSaferCustodyScreeningOutcome(
+          request = request,
+          referenceDataRepository::getActiveReferenceData,
+        ).toModel()
+          .apply { new = screening == null }
+      }
+
+    if (request.outcomeTypeCode == INVESTIGATION_REQUIRED) {
+      record.prisonCodeWhenRecorded?.let { prisonCode ->
+        jdaService.submitCaseNotesForAnalysis(
+          offenderIdentifier = record.prisonNumber,
+          prisonCode = prisonCode,
+          correlationId = referral.id.toString(),
+        )
+      }
+    }
+
+    return result
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNotesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNotesServiceTest.kt
@@ -2,19 +2,13 @@ package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.se
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.client.casenotes.CaseNotesClient
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.client.casenotes.CaseNotesRequest
-import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.config.CsipAssistConfig
-import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.constant.INVESTIGATION_REQUIRED
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.request.CaseNotesFilterParams
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.request.CaseNotesLookupRequest
 import java.time.Clock
@@ -23,75 +17,73 @@ import java.time.LocalDateTime
 import java.time.ZoneOffset
 
 class CaseNotesServiceTest {
-  private val caseNotesClient = mock<CaseNotesClient>()
-  private val csipAssistConfig = mock<CsipAssistConfig>()
-  private val fixedClock = Clock.fixed(Instant.parse("2026-07-21T07:00:00Z"), ZoneOffset.UTC)
-  private val service = CaseNotesService(caseNotesClient, csipAssistConfig, true, fixedClock)
-  private val serviceWithFeatureFalse = CaseNotesService(caseNotesClient, csipAssistConfig, false, fixedClock)
 
-  private lateinit var offenderIdentifier: String
+  private val caseNotesClient = mock<CaseNotesClient>()
+
+  private val fixedClock =
+    Clock.fixed(
+      Instant.parse("2026-07-21T07:00:00Z"),
+      ZoneOffset.UTC,
+    )
+
+  private val service =
+    CaseNotesService(
+      caseNotesClient,
+      fixedClock,
+    )
+
   private lateinit var request: CaseNotesLookupRequest
+
   private val params = CaseNotesFilterParams()
 
   @BeforeEach
   fun setUp() {
-    offenderIdentifier = "A1234AA"
-    request = CaseNotesLookupRequest(
-      offenderIdentifier = offenderIdentifier,
-      outcomeTypeCode = INVESTIGATION_REQUIRED,
-      includeSensitive = false,
-      caseload = "NMI",
-    )
+    request =
+      CaseNotesLookupRequest(
+        offenderIdentifier = "A1234AA",
+        includeSensitive = false,
+      )
   }
 
   @Test
-  @DisplayName("getCaseNotes calls to case notes client when feature flag is enabled outcome is $INVESTIGATION_REQUIRED and prison is active")
-  fun `getCaseNotes calls to case notes client when feature flag is enabled and prison is active`() {
-    whenever(csipAssistConfig.isActivePrison(request.caseload)).thenReturn(true)
-
-    service.getCaseNotes(request, params)
-    val caseNotesRequestCaptor = argumentCaptor<CaseNotesRequest>()
-
-    verify(csipAssistConfig).isActivePrison(request.caseload)
-    verify(caseNotesClient).getCaseNotes(eq(offenderIdentifier), caseNotesRequestCaptor.capture())
-
-    val sentRequest = caseNotesRequestCaptor.firstValue
-    val expectedNow = LocalDateTime.ofInstant(fixedClock.instant(), ZoneOffset.UTC)
-    assertThat(sentRequest.includeSensitive).isFalse()
-    assertThat(sentRequest.typeSubTypes).isEmpty()
-    assertThat(sentRequest.page).isEqualTo(1)
-    assertThat(sentRequest.size).isEqualTo(100)
-    assertThat(sentRequest.sort).isEqualTo("occurredAt,desc")
-    assertThat(sentRequest.occurredTo).isEqualTo(expectedNow)
-    assertThat(sentRequest.occurredFrom).isEqualTo(expectedNow.minusDays(90))
-  }
-
-  @Test
-  @DisplayName("getCaseNotes does not call case notes client when outcomeTypeCode is not $INVESTIGATION_REQUIRED")
-  fun `getCaseNotes does not call case notes client when outcomeTypeCode is not required outcome`() {
-    val nonOpeRequest = request.copy(outcomeTypeCode = "ACC")
-
-    service.getCaseNotes(nonOpeRequest, params)
-
-    verify(csipAssistConfig, never()).isActivePrison(any())
-    verify(caseNotesClient, never()).getCaseNotes(any(), any())
-  }
-
-  @Test
-  fun `getCaseNotes does not call case notes client when prison is not active`() {
-    whenever(csipAssistConfig.isActivePrison(request.caseload)).thenReturn(false)
-
+  fun `getCaseNotes calls case notes client with expected request`() {
     service.getCaseNotes(request, params)
 
-    verify(csipAssistConfig).isActivePrison(request.caseload)
-    verify(caseNotesClient, never()).getCaseNotes(any(), any())
-  }
+    val requestCaptor =
+      argumentCaptor<CaseNotesRequest>()
 
-  @Test
-  fun `getCaseNotes does not call case notes client when feature flag is false`() {
-    serviceWithFeatureFalse.getCaseNotes(request, params)
+    verify(caseNotesClient)
+      .getCaseNotes(
+        eq("A1234AA"),
+        requestCaptor.capture(),
+      )
 
-    verify(csipAssistConfig, never()).isActivePrison(any())
-    verify(caseNotesClient, never()).getCaseNotes(any(), any())
+    val sentRequest = requestCaptor.firstValue
+    val expectedNow =
+      LocalDateTime.ofInstant(
+        fixedClock.instant(),
+        ZoneOffset.UTC,
+      )
+
+    assertThat(sentRequest.includeSensitive)
+      .isFalse()
+
+    assertThat(sentRequest.typeSubTypes)
+      .isEmpty()
+
+    assertThat(sentRequest.page)
+      .isEqualTo(1)
+
+    assertThat(sentRequest.size)
+      .isEqualTo(100)
+
+    assertThat(sentRequest.sort)
+      .isEqualTo("occurredAt,desc")
+
+    assertThat(sentRequest.occurredTo)
+      .isEqualTo(expectedNow)
+
+    assertThat(sentRequest.occurredFrom)
+      .isEqualTo(expectedNow.minusDays(90))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNotesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNotesServiceTest.kt
@@ -41,7 +41,7 @@ class CaseNotesServiceTest {
     request =
       CaseNotesLookupRequest(
         offenderIdentifier = "A1234AA",
-        includeSensitive = false,
+        includeSensitive = true,
       )
   }
 
@@ -66,7 +66,7 @@ class CaseNotesServiceTest {
       )
 
     assertThat(sentRequest.includeSensitive)
-      .isFalse()
+      .isTrue()
 
     assertThat(sentRequest.typeSubTypes)
       .isEmpty()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/JdaServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/JdaServiceTest.kt
@@ -1,0 +1,169 @@
+package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.client.casenotes.CaseNote
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.client.casenotes.CaseNotesMetadata
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.client.casenotes.CaseNotesResponse
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.client.jda.JdaClient
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.config.CsipAssistConfig
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.CaseNoteAnalysisItem
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaRequest
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.request.CaseNotesLookupRequest
+import java.time.LocalDateTime
+import java.util.UUID
+
+class JdaServiceTest {
+
+  private val caseNotesService = mock<CaseNotesService>()
+  private val jdaClient = mock<JdaClient>()
+  private val csipAssistConfig = mock<CsipAssistConfig>()
+
+  private val service =
+    JdaService(
+      caseNotesService,
+      jdaClient,
+      csipAssistConfig,
+      true,
+    )
+
+  private val serviceWithFeatureDisabled =
+    JdaService(
+      caseNotesService,
+      jdaClient,
+      csipAssistConfig,
+      false,
+    )
+
+  private val offenderIdentifier = "A1234AA"
+  private val prisonCode = "NMI"
+  private val correlationId = "referral-id"
+
+  @Test
+  fun `submitCaseNotesForAnalysis submits request when feature enabled and prison active`() {
+    whenever(
+      csipAssistConfig.isActivePrison(prisonCode),
+    ).thenReturn(true)
+
+    val response = testCaseNotesResponse()
+
+    whenever(
+      caseNotesService.getCaseNotes(any(), any()),
+    ).thenReturn(response)
+
+    service.submitCaseNotesForAnalysis(
+      offenderIdentifier = offenderIdentifier,
+      prisonCode = prisonCode,
+      correlationId = correlationId,
+    )
+
+    verify(csipAssistConfig)
+      .isActivePrison(prisonCode)
+
+    val caseNotesLookupRequestCaptor = argumentCaptor<CaseNotesLookupRequest>()
+    verify(caseNotesService)
+      .getCaseNotes(caseNotesLookupRequestCaptor.capture(), any())
+
+    assertThat(caseNotesLookupRequestCaptor.firstValue.offenderIdentifier)
+      .isEqualTo(offenderIdentifier)
+    assertThat(caseNotesLookupRequestCaptor.firstValue.includeSensitive)
+      .isTrue()
+
+    val requestCaptor =
+      argumentCaptor<JdaRequest<List<CaseNoteAnalysisItem>>>()
+
+    verify(jdaClient)
+      .submitRequest(requestCaptor.capture())
+
+    assertThat(requestCaptor.firstValue.correlationId)
+      .isEqualTo(correlationId)
+
+    assertThat(requestCaptor.firstValue.prompt.key)
+      .isEqualTo("case-note-analysis")
+
+    assertThat(requestCaptor.firstValue.prompt.version)
+      .isEqualTo(3)
+
+    assertThat(requestCaptor.firstValue.requestData)
+      .hasSize(1)
+
+    assertThat(requestCaptor.firstValue.requestData.first().caseNoteText)
+      .isEqualTo("Prisoner became agitated")
+
+    assertThat(requestCaptor.firstValue.requestData.first().itemId)
+      .isEqualTo("f4ee95d0-49a4-46a2-a485-b8f26f089170")
+  }
+
+  @Test
+  fun `submitCaseNotesForAnalysis does nothing when feature flag disabled`() {
+    serviceWithFeatureDisabled.submitCaseNotesForAnalysis(
+      offenderIdentifier = offenderIdentifier,
+      prisonCode = prisonCode,
+      correlationId = correlationId,
+    )
+
+    verify(csipAssistConfig, never())
+      .isActivePrison(any())
+
+    verifyNoInteractions(caseNotesService)
+
+    verifyNoInteractions(jdaClient)
+  }
+
+  @Test
+  fun `submitCaseNotesForAnalysis does nothing when prison is not active`() {
+    whenever(
+      csipAssistConfig.isActivePrison(prisonCode),
+    ).thenReturn(false)
+
+    service.submitCaseNotesForAnalysis(
+      offenderIdentifier = offenderIdentifier,
+      prisonCode = prisonCode,
+      correlationId = correlationId,
+    )
+
+    verify(csipAssistConfig)
+      .isActivePrison(prisonCode)
+
+    verifyNoInteractions(caseNotesService)
+
+    verifyNoInteractions(jdaClient)
+  }
+
+  private fun testCaseNotesResponse(
+    caseNote: CaseNote = testCaseNote(),
+  ) = CaseNotesResponse(
+    content = listOf(caseNote),
+    hasCaseNotes = true,
+    metadata = CaseNotesMetadata(
+      totalElements = 1,
+      page = 0,
+      size = 1,
+    ),
+  )
+
+  private fun testCaseNote() = CaseNote(
+    caseNoteId = UUID.fromString("f4ee95d0-49a4-46a2-a485-b8f26f089170"),
+    offenderIdentifier = "A1234AA",
+    type = "GEN",
+    typeDescription = "General",
+    subType = "OBS",
+    subTypeDescription = "Observation",
+    creationDateTime = LocalDateTime.now(),
+    occurrenceDateTime = LocalDateTime.now(),
+    authorName = "Test User",
+    authorUserId = "USER1",
+    authorUsername = "testuser",
+    text = "Prisoner became agitated",
+    locationId = "MDI",
+    sensitive = false,
+    amendments = emptyList(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/SaferCustodyScreeningOutcomeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/SaferCustodyScreeningOutcomeServiceTest.kt
@@ -1,0 +1,171 @@
+package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.constant.INVESTIGATION_REQUIRED
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.domain.CsipRecord
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.domain.CsipRecordRepository
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.domain.referencedata.ReferenceData
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.domain.referencedata.ReferenceDataKey
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.domain.referencedata.ReferenceDataRepository
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.domain.referral.Referral
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.domain.toPersonSummary
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.enumeration.OptionalYesNoAnswer.DO_NOT_KNOW
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.enumeration.ReferenceDataType
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.enumeration.ReferenceDataType.AREA_OF_WORK
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.enumeration.ReferenceDataType.INCIDENT_LOCATION
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.enumeration.ReferenceDataType.INCIDENT_TYPE
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.enumeration.ReferenceDataType.SCREENING_OUTCOME_TYPE
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.referral.request.UpsertSaferCustodyScreeningOutcomeRequest
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.utils.EntityGenerator.generateCsipRecord
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.utils.prisoner
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.utils.set
+import java.time.LocalDate
+
+class SaferCustodyScreeningOutcomeServiceTest {
+
+  private val csipRecordRepository = mock<CsipRecordRepository>()
+  private val referenceDataRepository = mock<ReferenceDataRepository>()
+  private val jdaService = mock<JdaService>()
+
+  private val service = SaferCustodyScreeningOutcomeService(
+    csipRecordRepository,
+    referenceDataRepository,
+    jdaService,
+  )
+
+  private val prisonNumber = "A1234AA"
+  private val prisonCode = "NMI"
+
+  private lateinit var record: CsipRecord
+
+  @BeforeEach
+  fun setUp() {
+    record = generateCsipRecord(
+      personSummary = prisoner(prisonerNumber = prisonNumber).toPersonSummary(),
+      prisonCodeWhenRecorded = prisonCode,
+    )
+
+    val referral = Referral(
+      csipRecord = record,
+      referralDate = LocalDate.now(),
+      incidentDate = LocalDate.now(),
+      referredBy = "referredBy",
+      descriptionOfConcern = null,
+      knownReasons = null,
+      saferCustodyTeamInformed = DO_NOT_KNOW,
+      incidentType = referenceData(INCIDENT_TYPE, "INT"),
+      incidentLocation = referenceData(INCIDENT_LOCATION, "LOC"),
+      refererAreaOfWork = referenceData(AREA_OF_WORK, "AOW"),
+      incidentInvolvement = null,
+    )
+
+    record.set(record::referral, referral)
+
+    whenever(csipRecordRepository.findById(record.id)).thenReturn(record)
+  }
+
+  @Test
+  fun `should submit case notes for analysis when outcome is investigation required`() {
+    whenever(
+      referenceDataRepository.findByKey(ReferenceDataKey(SCREENING_OUTCOME_TYPE, INVESTIGATION_REQUIRED)),
+    ).thenReturn(referenceData(SCREENING_OUTCOME_TYPE, INVESTIGATION_REQUIRED))
+
+    service.upsertScreeningOutcome(
+      record.id,
+      upsertScreeningOutcomeRequest(outcomeTypeCode = INVESTIGATION_REQUIRED),
+    )
+
+    val offenderIdentifierCaptor = argumentCaptor<String>()
+    val prisonCodeCaptor = argumentCaptor<String>()
+    val correlationIdCaptor = argumentCaptor<String>()
+
+    verify(jdaService).submitCaseNotesForAnalysis(
+      offenderIdentifier = offenderIdentifierCaptor.capture(),
+      prisonCode = prisonCodeCaptor.capture(),
+      correlationId = correlationIdCaptor.capture(),
+    )
+
+    assertThat(offenderIdentifierCaptor.firstValue)
+      .isEqualTo(prisonNumber)
+
+    assertThat(prisonCodeCaptor.firstValue)
+      .isEqualTo(prisonCode)
+
+    assertThat(correlationIdCaptor.firstValue)
+      .isEqualTo(record.referral!!.id.toString())
+  }
+
+  @Test
+  fun `should not submit case notes for analysis when outcome is not investigation required`() {
+    whenever(
+      referenceDataRepository.findByKey(ReferenceDataKey(SCREENING_OUTCOME_TYPE, "CUR")),
+    ).thenReturn(referenceData(SCREENING_OUTCOME_TYPE, "CUR"))
+
+    service.upsertScreeningOutcome(
+      record.referral!!.id,
+      upsertScreeningOutcomeRequest(outcomeTypeCode = "CUR"),
+    )
+
+    verifyNoInteractions(jdaService)
+  }
+
+  @Test
+  fun `should not submit case notes for analysis when prison code when recorded is null`() {
+    val recordWithNoPrisonCode = generateCsipRecord(
+      personSummary = prisoner(prisonerNumber = prisonNumber).toPersonSummary(),
+      prisonCodeWhenRecorded = null,
+    )
+
+    val referral = Referral(
+      csipRecord = recordWithNoPrisonCode,
+      referralDate = LocalDate.now(),
+      incidentDate = LocalDate.now(),
+      referredBy = "referredBy",
+      descriptionOfConcern = null,
+      knownReasons = null,
+      saferCustodyTeamInformed = DO_NOT_KNOW,
+      incidentType = referenceData(INCIDENT_TYPE, "INT"),
+      incidentLocation = referenceData(INCIDENT_LOCATION, "LOC"),
+      refererAreaOfWork = referenceData(AREA_OF_WORK, "AOW"),
+      incidentInvolvement = null,
+    )
+
+    recordWithNoPrisonCode.set(recordWithNoPrisonCode::referral, referral)
+
+    whenever(csipRecordRepository.findById(recordWithNoPrisonCode.id)).thenReturn(recordWithNoPrisonCode)
+    whenever(
+      referenceDataRepository.findByKey(ReferenceDataKey(SCREENING_OUTCOME_TYPE, INVESTIGATION_REQUIRED)),
+    ).thenReturn(referenceData(SCREENING_OUTCOME_TYPE, INVESTIGATION_REQUIRED))
+
+    service.upsertScreeningOutcome(
+      recordWithNoPrisonCode.id,
+      upsertScreeningOutcomeRequest(outcomeTypeCode = INVESTIGATION_REQUIRED),
+    )
+
+    verifyNoInteractions(jdaService)
+  }
+
+  private fun upsertScreeningOutcomeRequest(
+    outcomeTypeCode: String = INVESTIGATION_REQUIRED,
+  ) = UpsertSaferCustodyScreeningOutcomeRequest(
+    outcomeTypeCode = outcomeTypeCode,
+    date = LocalDate.now(),
+    reasonForDecision = "A reason for the decision",
+    recordedBy = "recordedBy",
+    recordedByDisplayName = "Recorded By",
+  )
+
+  private fun referenceData(domain: ReferenceDataType, code: String) = ReferenceData(
+    key = ReferenceDataKey(domain, code),
+    description = code,
+    listSequence = 1,
+    deactivatedAt = null,
+  )
+}


### PR DESCRIPTION
# JDA-361 Trigger CSIP Assist JDA analysis for investigation outcomes

## Summary

This PR introduces the initial CSIP Assist orchestration flow for screening outcomes that require an investigation.

When a safer custody screening outcome is recorded as `INVESTIGATION_REQUIRED`, the service now:

```text
Screening Outcome Updated
        ↓
Investigation Required
        ↓
Retrieve Case Notes
        ↓
Map to JDA Request
        ↓
Submit to JDA Client
```

This PR intentionally does not implement the JDA HTTP integration itself.

`JdaClient.submitRequest()` and `JdaClient.queueRequest()` remain TODO stubs and continue to act as the integration boundary for future JDA implementation work.

The requirement for this work is that when a screening outcome is recorded as:

```text
INVESTIGATION_REQUIRED
```

the application should:

1. Retrieve relevant case notes
2. Create a JDA request payload
3. Submit that request to the JDA client

## Architectural Changes

### Introduced JdaService

A new orchestration layer has been introduced:

```text
SaferCustodyScreeningOutcomeService
        ↓
JdaService
        ↓
CaseNotesService
        ↓
CaseNotesClient
        ↓
JdaClient
```

### Why Introduce JdaService?

Prior to this refactor, `CaseNotesService` contained both retrieval and orchestration responsibilities, including:

- Feature flag checks
- Investigation outcome checks
- Active prison checks
- Case note retrieval

This resulted in a service that was responsible for both business workflow decisions and retrieving case notes.

Introducing `JdaService` allows orchestration concerns to be separated from retrieval concerns.

### JdaService Responsibilities

`JdaService` is now responsible for:

- CSIP Assist feature flag checks
- Active prison checks
- Triggering case note retrieval
- Mapping case notes into a JDA request
- Submitting requests to the JDA client

### CaseNotesService Responsibilities

`CaseNotesService` is now responsible only for:

```text
Retrieving case notes
```

This gives the service a single responsibility and removes JDA-specific orchestration logic from the retrieval layer.

## Simplified CaseNotesLookupRequest

### Removed Fields

The following fields were removed from `CaseNotesLookupRequest`:

```kotlin
outcomeTypeCode
caseload
```

### Why Were They Removed?

These fields were originally required because `CaseNotesService` performed orchestration decisions such as:

- Investigation outcome checks
- Active prison checks

Following the introduction of `JdaService`, these decisions now occur before case note retrieval.

As a result, neither field is actually required for retrieving case notes.

The request model now contains only the information required by the Case Notes retrieval process:

```kotlin
data class CaseNotesLookupRequest(
  val offenderIdentifier: String,
  val includeSensitive: Boolean = false,
)
```

This makes the request model more accurate and reduces coupling between:

- CSIP Assist orchestration
- Case Notes retrieval

## Screening Outcome Changes

`SaferCustodyScreeningOutcomeService` now triggers the CSIP Assist workflow when:

```kotlin
request.outcomeTypeCode == INVESTIGATION_REQUIRED
```

The service passes:

- Offender identifier
- Prison code
- Referral ID

to `JdaService`.

No JDA processing occurs for any other screening outcome.

## Sensitive Case Notes

Case note retrieval now includes sensitive case notes:

```kotlin
includeSensitive = true
```

This was agreed for the initial testing phase to maximise the information available for CSIP Assist analysis.

Future handling of sensitive case notes will be addressed separately.

## Correlation ID

JDA requests now use the CSIP Referral ID as the correlation identifier:

```kotlin
correlationId = referral.id.toString()
```

This aligns with the agreed JDA integration design.

## Testing

### Added

#### SaferCustodyScreeningOutcomeServiceTest

Verifies:

- Investigation Required outcomes trigger JDA processing
- Non-investigation outcomes do not trigger JDA processing
- Investigation Required outcomes with no prison code do not trigger JDA processing

#### JdaServiceTest

Verifies:

- Feature flag behaviour
- Active prison behaviour
- Case note retrieval
- JDA request creation
- JDA submission

### Updated

#### CaseNotesServiceTest

Refactored to validate case note retrieval behaviour only.

Removed tests covering:

- Feature flag checks
- Investigation outcome checks
- Active prison checks

These responsibilities now belong to `JdaService`.

## Resulting Flow

```text
SaferCustodyScreeningOutcomeService
        │
        ├─ Investigation Required?
        │
        ▼
JdaService
        │
        ├─ Feature enabled?
        ├─ Active prison?
        │
        ▼
CaseNotesService
        │
        ▼
CaseNotesClient
        │
        ▼
CaseNotesResponse
        │
        ▼
toJdaRequest()
        │
        ▼
JdaClient.submitRequest()
```

## Out of Scope

This PR does not implement:

- JDA HTTP communication
- Asynchronous JDA processing
- Special handling of sensitive case notes

These concerns remain the responsibility of future JDA integration work.