### PR TITLE
JDA-350 implement cronjob to get casenote annotations from JDA Api

### DIFF
--- a/helm_deploy/hmpps-challenge-support-intervention-plan-api/templates/case-note-annotations-job.yaml
+++ b/helm_deploy/hmpps-challenge-support-intervention-plan-api/templates/case-note-annotations-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.caseNoteAnnotations.enabled }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -21,5 +22,6 @@ spec:
               args:
                 - /bin/sh
                 - -c
-                - curl --retry 2 -XPOST http://hmpps-challenge-support-intervention-plan-api/queue/case-note-annotations
+                - curl --fail --retry 2 --max-time 55 --retry-max-time 55 -X POST http://hmpps-challenge-support-intervention-plan-api/queue/case-note-annotations
           restartPolicy: Never
+{{- end }}

--- a/helm_deploy/hmpps-challenge-support-intervention-plan-api/templates/case-note-annotations-job.yaml
+++ b/helm_deploy/hmpps-challenge-support-intervention-plan-api/templates/case-note-annotations-job.yaml
@@ -21,8 +21,5 @@ spec:
               args:
                 - /bin/sh
                 - -c
-                - |
-                  curl --retry 2 -XPOST http://hmpps-challenge-support-intervention-plan-api/queue/case-note-annotations
-                  sleep 30
-                  curl --retry 2 -XPOST http://hmpps-challenge-support-intervention-plan-api/queue/case-note-annotations
+                - curl --retry 2 -XPOST http://hmpps-challenge-support-intervention-plan-api/queue/case-note-annotations
           restartPolicy: Never

--- a/helm_deploy/hmpps-challenge-support-intervention-plan-api/templates/case-note-annotations-job.yaml
+++ b/helm_deploy/hmpps-challenge-support-intervention-plan-api/templates/case-note-annotations-job.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: csip-case-note-annotations
+spec:
+  schedule: "{{ .Values.caseNoteAnnotations.schedule }}"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 2
+  startingDeadlineSeconds: 600
+  successfulJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            cron-job-name: case-note-annotations-cronjob
+        spec:
+          containers:
+            - name: case-note-annotations
+              image: ghcr.io/ministryofjustice/hmpps-devops-tools
+              args:
+                - /bin/sh
+                - -c
+                - |
+                  curl --retry 2 -XPOST http://hmpps-challenge-support-intervention-plan-api/queue/case-note-annotations
+                  sleep 30
+                  curl --retry 2 -XPOST http://hmpps-challenge-support-intervention-plan-api/queue/case-note-annotations
+          restartPolicy: Never

--- a/helm_deploy/hmpps-challenge-support-intervention-plan-api/values.yaml
+++ b/helm_deploy/hmpps-challenge-support-intervention-plan-api/values.yaml
@@ -100,5 +100,5 @@ reconciliation:
     schedule: "0 7 * * 0"
 
 caseNoteAnnotations:
-  # Kubernetes CronJob runs this job every minute.
+  enabled: false
   schedule: "*/1 * * * *"

--- a/helm_deploy/hmpps-challenge-support-intervention-plan-api/values.yaml
+++ b/helm_deploy/hmpps-challenge-support-intervention-plan-api/values.yaml
@@ -31,6 +31,10 @@ generic-service:
           deny all;
           return 401;
         }
+        location /queue/case-note-annotations {
+          deny all;
+          return 401;
+        }
 
   # Used to access resources like S3 buckets, SQS queues and SNS topics
   serviceAccountName: hmpps-challenge-support-intervention-plan-api
@@ -94,3 +98,7 @@ generic-data-analytics-extractor:
 reconciliation:
   person:
     schedule: "0 7 * * 0"
+
+caseNoteAnnotations:
+  # Kubernetes CronJob supports minute granularity; run twice per minute in the job script.
+  schedule: "*/1 * * * *"

--- a/helm_deploy/hmpps-challenge-support-intervention-plan-api/values.yaml
+++ b/helm_deploy/hmpps-challenge-support-intervention-plan-api/values.yaml
@@ -100,5 +100,5 @@ reconciliation:
     schedule: "0 7 * * 0"
 
 caseNoteAnnotations:
-  # Kubernetes CronJob supports minute granularity; run twice per minute in the job script.
+  # Kubernetes CronJob runs this job every minute.
   schedule: "*/1 * * * *"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -44,3 +44,6 @@ generic-prometheus-alerts:
 generic-data-analytics-extractor:
   enabled: true
   cronJobSchedule: "0 1 * * 1-5"
+
+caseNoteAnnotations:
+  enabled: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -10,7 +10,7 @@ generic-service:
     API_BASE_URL_HMPPS_AUTH: "https://sign-in.hmpps.service.justice.gov.uk/auth"
     API_BASE_URL_MANAGE_USERS: "https://manage-users-api.hmpps.service.justice.gov.uk"
     API_BASE_URL_CASENOTES: "https://offender-case-notes.service.justice.gov.uk"
-    API_BASE_URL_JDA: " https://justice-data-agent-client-api.hmpps.service.justice.gov.uk/"
+    API_BASE_URL_JDA: "https://justice-data-agent-client-api.hmpps.service.justice.gov.uk/"
     API_BASE_URL_PRISONER_SEARCH: "https://prisoner-search.prison.service.justice.gov.uk"
     SERVICE_BASE_URL: "https://csip-api.hmpps.service.justice.gov.uk"
     SERVICE_ACTIVE_PRISONS: "***"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/client/jda/JdaClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/client/jda/JdaClient.kt
@@ -1,8 +1,15 @@
 package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.client.jda
 
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToMono
+import reactor.core.publisher.Mono
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.client.retryIdempotentRequestOnTransientException
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.exception.DownstreamServiceException
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaDequeueResponse
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaRequest
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaRequestResponse
 
@@ -19,4 +26,22 @@ class JdaClient(
   fun <T> queueRequest(
     request: JdaRequest<T>,
   ): JdaRequestResponse = TODO("Future asynchronous JDA integration")
+
+  fun getCaseNoteAnnotationsFromQueue(): JdaDequeueResponse? = try {
+    webClient
+      .get()
+      .uri("/v1/dequeueresponse")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchangeToMono { res ->
+        when (res.statusCode()) {
+          HttpStatus.OK -> res.bodyToMono<JdaDequeueResponse>()
+          HttpStatus.NOT_FOUND -> Mono.empty()
+          else -> res.createError()
+        }
+      }
+      .retryIdempotentRequestOnTransientException()
+      .block()
+  } catch (e: Exception) {
+    throw DownstreamServiceException("Get case note annotations from queue failed", e)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/config/SecurityConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/config/SecurityConfig.kt
@@ -9,7 +9,11 @@ class SecurityConfig {
   @Bean
   fun resourceServerCustomizer() = ResourceServerConfigurationCustomizer {
     unauthorizedRequestPaths {
-      addPaths = setOf("/queue-admin/retry-all-dlqs", "/reconciliation/person")
+      addPaths = setOf(
+        "/queue-admin/retry-all-dlqs",
+        "/reconciliation/person",
+        "/queue/case-note-annotations",
+      )
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/controller/CaseNoteAnnotationsJobController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/controller/CaseNoteAnnotationsJobController.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.service.CaseNoteAnnotationsService
+
+@RestController
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+class CaseNoteAnnotationsJobController(private val caseNoteAnnotationsService: CaseNoteAnnotationsService) {
+  @Operation(hidden = true)
+  @PostMapping("/queue/case-note-annotations")
+  fun processQueuedCaseNoteAnnotations() {
+    caseNoteAnnotationsService.getCaseNoteAnnotationsFromQueue()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaDequeueResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaDequeueResponse.kt
@@ -1,15 +1,15 @@
 package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import java.time.Instant
-import java.util.*
+import java.time.OffsetDateTime
+import java.util.UUID
 
 data class JdaDequeueResponse(
   val requestId: UUID,
   val correlationId: String,
   val prompt: JdaPrompt,
   val status: JdaDequeueResponseStatus,
-  val responseData: Any,
+  val responseData: JdaDequeueResponseData?,
   val metadata: JdaDequeueResponseMetadata,
 )
 
@@ -31,6 +31,6 @@ data class JdaDequeueResponseData(
 
 data class JdaDequeueResponseMetadata(
   val requestType: JdaRequestType,
-  val completedAt: Instant,
+  val completedAt: OffsetDateTime,
   val completionMs: Long,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaDequeueResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaDequeueResponse.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.time.Instant
+import java.util.*
+
+data class JdaDequeueResponse(
+  val requestId: UUID,
+  val correlationId: String,
+  val prompt: JdaPrompt,
+  val status: JdaDequeueResponseStatus,
+  val responseData: Any,
+  val metadata: JdaDequeueResponseMetadata,
+)
+
+enum class JdaDequeueResponseStatus {
+
+  @JsonProperty("succeeded")
+  SUCCEEDED,
+
+  @JsonProperty("failed")
+  FAILED,
+
+  @JsonProperty("rejected")
+  REJECTED,
+}
+
+data class JdaDequeueResponseData(
+  val todo: String,
+)
+
+data class JdaDequeueResponseMetadata(
+  val requestType: JdaRequestType,
+  val completedAt: Instant,
+  val completionMs: Long,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaRequestResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaRequestResponse.kt
@@ -6,5 +6,6 @@ data class JdaRequestResponse(
   val requestId: UUID,
   val correlationId: String,
   val prompt: JdaPrompt,
+  val status: JdaRequestStatus,
   val metadata: JdaRequestMetadata,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaRequestResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaRequestResponse.kt
@@ -6,6 +6,5 @@ data class JdaRequestResponse(
   val requestId: UUID,
   val correlationId: String,
   val prompt: JdaPrompt,
-  val status: JdaRequestStatus,
   val metadata: JdaRequestMetadata,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNoteAnnotationsPersistenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNoteAnnotationsPersistenceService.kt
@@ -10,5 +10,3 @@ class CaseNoteAnnotationsPersistenceService {
     // TODO
   }
 }
-
-

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNoteAnnotationsPersistenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNoteAnnotationsPersistenceService.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaDequeueResponse
+
+@Service
+class CaseNoteAnnotationsPersistenceService {
+  @Suppress("UNUSED_PARAMETER")
+  fun persistCaseNoteAnnotations(dequeuedResponse: JdaDequeueResponse) {
+    // TODO
+  }
+}
+
+

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNoteAnnotationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNoteAnnotationsService.kt
@@ -4,7 +4,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.client.jda.JdaClient
-import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaDequeueResponse
 
 @Service
 class CaseNoteAnnotationsService(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNoteAnnotationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNoteAnnotationsService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.mod
 @Service
 class CaseNoteAnnotationsService(
   private val jdaClient: JdaClient,
+  private val caseNoteAnnotationsPersistenceService: CaseNoteAnnotationsPersistenceService,
 ) {
 
   private companion object {
@@ -16,19 +17,21 @@ class CaseNoteAnnotationsService(
   }
 
   fun getCaseNoteAnnotationsFromQueue() {
-    log.info("Fetching case note annotations from queue")
     var response = jdaClient.getCaseNoteAnnotationsFromQueue()
-
+    var count = 0
     while (response != null) {
-      log.debug("Fetched case note annotations for requestId=${response.requestId}")
-      persistCaseNoteAnnotations(response)
+      try {
+        caseNoteAnnotationsPersistenceService.persistCaseNoteAnnotations(response)
+        count++
+      } catch (e: Exception) {
+        log.error("Failed to persist case note annotation for request ${response.requestId}", e)
+        // TODO need to save the failed annotation persistence somewhere so it isn't just lost - DLQ, or a staging table etc
+      }
       response = jdaClient.getCaseNoteAnnotationsFromQueue()
     }
 
-    log.info("No more case note annotations available in queue")
-  }
-
-  private fun persistCaseNoteAnnotations(dequeuedResponse: JdaDequeueResponse) {
-    // TODO
+    if (count > 0) {
+      log.info("Processed $count case note annotations")
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNoteAnnotationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNoteAnnotationsService.kt
@@ -24,7 +24,7 @@ class CaseNoteAnnotationsService(
         count++
       } catch (e: Exception) {
         log.error("Failed to persist case note annotation for request ${response.requestId}", e)
-        // TODO need to save the failed annotation persistence somewhere so it isn't just lost - DLQ, or a staging table etc
+        // TODO may need to save the failed annotation persistence but this is not in current scope
       }
       response = jdaClient.getCaseNoteAnnotationsFromQueue()
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNoteAnnotationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNoteAnnotationsService.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.service
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.client.jda.JdaClient
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaDequeueResponse
+
+@Service
+class CaseNoteAnnotationsService(
+  private val jdaClient: JdaClient,
+) {
+
+  private companion object {
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun getCaseNoteAnnotationsFromQueue() {
+    log.info("Fetching case note annotations from queue")
+    var response = jdaClient.getCaseNoteAnnotationsFromQueue()
+
+    while (response != null) {
+      log.debug("Fetched case note annotations for requestId=${response.requestId}")
+      persistCaseNoteAnnotations(response)
+      response = jdaClient.getCaseNoteAnnotationsFromQueue()
+    }
+
+    log.info("No more case note annotations available in queue")
+  }
+
+  private fun persistCaseNoteAnnotations(dequeuedResponse: JdaDequeueResponse) {
+    // TODO
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/client/jda/JdaClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/client/jda/JdaClientTest.kt
@@ -1,0 +1,98 @@
+package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.client.jda
+
+import com.github.tomakehurst.wiremock.client.WireMock.exactly
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.exception.DownstreamServiceException
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.integration.wiremock.JdaMockServer
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaDequeueResponse
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaDequeueResponseData
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaDequeueResponseMetadata
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaDequeueResponseStatus
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaPrompt
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaRequestType
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class JdaClientTest {
+  private lateinit var client: JdaClient
+
+  @BeforeEach
+  fun resetMocks() {
+    server.resetRequests()
+    val webClient = WebClient.create("http://localhost:${server.port()}")
+    client = JdaClient(webClient)
+  }
+
+  @Test
+  fun `getCaseNoteAnnotationsFromQueue - success`() {
+    server.stubDequeueResponse()
+
+    val result = client.getCaseNoteAnnotationsFromQueue()
+
+    assertThat(result).isEqualTo(
+      JdaDequeueResponse(
+        requestId = UUID.fromString("f091bc73-4f88-4ff6-9e50-5148d29ed3f6"),
+        correlationId = "f4f7ac6f-1d75-472f-a3a0-f0ee8a33fbbb",
+        prompt = JdaPrompt.caseNoteAnalysis(),
+        status = JdaDequeueResponseStatus.SUCCEEDED,
+        responseData = JdaDequeueResponseData(
+          todo = "todo",
+        ),
+        metadata = JdaDequeueResponseMetadata(
+          requestType = JdaRequestType.ASYNC,
+          completedAt = OffsetDateTime.parse("2026-06-27T09:55:03Z"),
+          completionMs = 1200,
+        ),
+      ),
+    )
+
+    server.verify(exactly(1), getRequestedFor(urlEqualTo("/v1/dequeueresponse")))
+  }
+
+  @Test
+  fun `getCaseNoteAnnotationsFromQueue - not found returns null`() {
+    server.stubDequeueResponseNotFound()
+
+    val result = client.getCaseNoteAnnotationsFromQueue()
+
+    assertThat(result).isNull()
+    server.verify(exactly(1), getRequestedFor(urlEqualTo("/v1/dequeueresponse")))
+  }
+
+  @Test
+  fun `getCaseNoteAnnotationsFromQueue - downstream service exception`() {
+    server.stubDequeueResponseException()
+
+    val exception = assertThrows<DownstreamServiceException> { client.getCaseNoteAnnotationsFromQueue() }
+
+    assertThat(exception.message).isEqualTo("Get case note annotations from queue failed")
+    assertThat(exception.cause).isInstanceOf(WebClientResponseException::class.java)
+    server.verify(exactly(4), getRequestedFor(urlEqualTo("/v1/dequeueresponse")))
+  }
+
+  companion object {
+    @JvmField
+    internal val server = JdaMockServer()
+
+    @BeforeAll
+    @JvmStatic
+    fun startMocks() {
+      server.start()
+    }
+
+    @AfterAll
+    @JvmStatic
+    fun stopMocks() {
+      server.stop()
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/controller/CaseNoteAnnotationsJobControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/controller/CaseNoteAnnotationsJobControllerIntTest.kt
@@ -1,0 +1,110 @@
+package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.controller
+
+import com.github.tomakehurst.wiremock.client.WireMock.exactly
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
+import org.awaitility.kotlin.withPollDelay
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.integration.wiremock.JdaMockServer
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.service.CaseNoteAnnotationsService
+import java.time.Duration.ofSeconds
+
+class CaseNoteAnnotationsJobControllerIntTest : IntegrationTestBase() {
+
+  @MockitoSpyBean
+  private lateinit var caseNoteAnnotationsService: CaseNoteAnnotationsService
+
+  @BeforeEach
+  fun resetMocks() {
+    jdaServer.resetRequests()
+  }
+
+  @Test
+  fun `successfully processes all available case note annotations from queue`() {
+    jdaServer.stubDequeueResponseThenNotFound()
+
+    webTestClient.post()
+      .uri("/queue/case-note-annotations")
+      .exchange()
+      .expectStatus().isOk
+
+    await withPollDelay ofSeconds(1) untilCallTo { dequeueRequestCount() } matches { it == 2 }
+
+    verify(caseNoteAnnotationsService, times(1)).getCaseNoteAnnotationsFromQueue()
+    jdaServer.verify(exactly(2), getRequestedFor(urlEqualTo("/v1/dequeueresponse")))
+  }
+
+  @Test
+  fun `handles empty queue gracefully`() {
+    jdaServer.stubDequeueResponseNotFound()
+
+    webTestClient.post()
+      .uri("/queue/case-note-annotations")
+      .exchange()
+      .expectStatus().isOk
+
+    await withPollDelay ofSeconds(1) untilCallTo { dequeueRequestCount() } matches { it == 1 }
+
+    verify(caseNoteAnnotationsService, times(1)).getCaseNoteAnnotationsFromQueue()
+    jdaServer.verify(exactly(1), getRequestedFor(urlEqualTo("/v1/dequeueresponse")))
+  }
+
+  @Test
+  fun `fails when downstream service denies access`() {
+    jdaServer.stubDequeueResponseUnauthorized()
+
+    webTestClient.post()
+      .uri("/queue/case-note-annotations")
+      .exchange()
+      .expectStatus().is5xxServerError
+
+    await withPollDelay ofSeconds(1) untilCallTo { dequeueRequestCount() } matches { it == 1 }
+
+    verify(caseNoteAnnotationsService, times(1)).getCaseNoteAnnotationsFromQueue()
+    jdaServer.verify(exactly(1), getRequestedFor(urlEqualTo("/v1/dequeueresponse")))
+  }
+
+  @Test
+  fun `retries on transient failures from downstream service`() {
+    jdaServer.stubDequeueResponseException()
+
+    webTestClient.post()
+      .uri("/queue/case-note-annotations")
+      .exchange()
+      .expectStatus().is5xxServerError
+
+    await withPollDelay ofSeconds(1) untilCallTo { dequeueRequestCount() } matches { it == 4 }
+
+    verify(caseNoteAnnotationsService, times(1)).getCaseNoteAnnotationsFromQueue()
+    jdaServer.verify(exactly(4), getRequestedFor(urlEqualTo("/v1/dequeueresponse")))
+  }
+
+  private fun dequeueRequestCount() = jdaServer.findAll(getRequestedFor(urlEqualTo("/v1/dequeueresponse"))).size
+
+  companion object {
+    @JvmField
+    internal val jdaServer = JdaMockServer()
+
+    @BeforeAll
+    @JvmStatic
+    fun startMocks() {
+      jdaServer.start()
+    }
+
+    @AfterAll
+    @JvmStatic
+    fun stopMocks() {
+      jdaServer.stop()
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/integration/wiremock/JdaMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/integration/wiremock/JdaMockServer.kt
@@ -3,8 +3,8 @@ package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.in
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
-import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
 
 class JdaMockServer : WireMockServer(8114) {
   private companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/integration/wiremock/JdaMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/integration/wiremock/JdaMockServer.kt
@@ -1,0 +1,101 @@
+package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.integration.wiremock
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED
+
+class JdaMockServer : WireMockServer(8114) {
+  private companion object {
+    const val DEQUEUE_SCENARIO = "jda-dequeue"
+    const val AFTER_FIRST_DEQUEUE = "after-first-dequeue"
+  }
+
+  fun stubDequeueResponse(): StubMapping = stubFor(
+    get("/v1/dequeueresponse")
+      .willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withBody(
+            """
+            {
+              "requestId": "f091bc73-4f88-4ff6-9e50-5148d29ed3f6",
+              "correlationId": "f4f7ac6f-1d75-472f-a3a0-f0ee8a33fbbb",
+              "prompt": {
+                "key": "case-note-analysis",
+                "version": 3
+              },
+              "status": "succeeded",
+              "responseData": {
+                "todo": "todo"
+              },
+              "metadata": {
+                "requestType": "async",
+                "completedAt": "2026-06-27T09:55:03Z",
+                "completionMs": 1200
+              }
+            }
+            """.trimIndent(),
+          )
+          .withStatus(200),
+      ),
+  )
+
+  fun stubDequeueResponseThenNotFound() {
+    stubFor(
+      get("/v1/dequeueresponse")
+        .inScenario(DEQUEUE_SCENARIO)
+        .whenScenarioStateIs(STARTED)
+        .willSetStateTo(AFTER_FIRST_DEQUEUE)
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """
+              {
+                "requestId": "f091bc73-4f88-4ff6-9e50-5148d29ed3f6",
+                "correlationId": "f4f7ac6f-1d75-472f-a3a0-f0ee8a33fbbb",
+                "prompt": {
+                  "key": "case-note-analysis",
+                  "version": 3
+                },
+                "status": "succeeded",
+                "responseData": {
+                  "todo": "todo"
+                },
+                "metadata": {
+                  "requestType": "async",
+                  "completedAt": "2026-06-27T09:55:03Z",
+                  "completionMs": 1200
+                }
+              }
+              """.trimIndent(),
+            )
+            .withStatus(200),
+        ),
+    )
+
+    stubFor(
+      get("/v1/dequeueresponse")
+        .inScenario(DEQUEUE_SCENARIO)
+        .whenScenarioStateIs(AFTER_FIRST_DEQUEUE)
+        .willReturn(aResponse().withStatus(404)),
+    )
+  }
+
+  fun stubDequeueResponseNotFound(): StubMapping = stubFor(
+    get("/v1/dequeueresponse")
+      .willReturn(aResponse().withStatus(404)),
+  )
+
+  fun stubDequeueResponseUnauthorized(): StubMapping = stubFor(
+    get("/v1/dequeueresponse")
+      .willReturn(aResponse().withStatus(401)),
+  )
+
+  fun stubDequeueResponseException(): StubMapping = stubFor(
+    get("/v1/dequeueresponse")
+      .willReturn(aResponse().withStatus(500)),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNoteAnnotationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNoteAnnotationsServiceTest.kt
@@ -1,0 +1,67 @@
+package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.service
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.client.jda.JdaClient
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.exception.DownstreamServiceException
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaDequeueResponse
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaDequeueResponseData
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaDequeueResponseMetadata
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaDequeueResponseStatus
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaPrompt
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaRequestType
+import java.time.Instant
+import java.util.UUID
+
+class CaseNoteAnnotationsServiceTest {
+  private val jdaClient = mock<JdaClient>()
+  private val service = CaseNoteAnnotationsService(jdaClient)
+
+  @Test
+  fun `getCaseNoteAnnotationsFromQueue polls when dequeue returns null`() {
+    whenever(jdaClient.getCaseNoteAnnotationsFromQueue())
+      .thenReturn(testResponse())
+      .thenReturn(testResponse())
+      .thenReturn(null)
+
+    service.getCaseNoteAnnotationsFromQueue()
+
+    verify(jdaClient, times(3)).getCaseNoteAnnotationsFromQueue()
+  }
+
+  @Test
+  fun `getCaseNoteAnnotationsFromQueue rethrows downstream failures`() {
+    whenever(jdaClient.getCaseNoteAnnotationsFromQueue())
+      .thenThrow(
+        DownstreamServiceException(
+          "Get case note annotations from queue failed",
+          RuntimeException("Something went wrong"),
+        ),
+      )
+
+    assertThrows<DownstreamServiceException> {
+      service.getCaseNoteAnnotationsFromQueue()
+    }
+
+    verify(jdaClient).getCaseNoteAnnotationsFromQueue()
+  }
+
+  private fun testResponse() = JdaDequeueResponse(
+    requestId = UUID.randomUUID(),
+    correlationId = UUID.randomUUID().toString(),
+    prompt = JdaPrompt.caseNoteAnalysis(),
+    status = JdaDequeueResponseStatus.SUCCEEDED,
+    responseData = JdaDequeueResponseData(
+      todo = "todo",
+    ),
+    metadata = JdaDequeueResponseMetadata(
+      requestType = JdaRequestType.ASYNC,
+      completedAt = Instant.now(),
+      completionMs = 1200,
+    ),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNoteAnnotationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNoteAnnotationsServiceTest.kt
@@ -2,7 +2,10 @@ package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.se
 
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -14,15 +17,16 @@ import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.mod
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaDequeueResponseStatus
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaPrompt
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda.JdaRequestType
-import java.time.Instant
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class CaseNoteAnnotationsServiceTest {
   private val jdaClient = mock<JdaClient>()
-  private val service = CaseNoteAnnotationsService(jdaClient)
+  private val caseNoteAnnotationsPersistenceService = mock<CaseNoteAnnotationsPersistenceService>()
+  private val service = CaseNoteAnnotationsService(jdaClient, caseNoteAnnotationsPersistenceService)
 
   @Test
-  fun `getCaseNoteAnnotationsFromQueue polls when dequeue returns null`() {
+  fun `getCaseNoteAnnotationsFromQueue polls until dequeue returns null`() {
     whenever(jdaClient.getCaseNoteAnnotationsFromQueue())
       .thenReturn(testResponse())
       .thenReturn(testResponse())
@@ -31,10 +35,11 @@ class CaseNoteAnnotationsServiceTest {
     service.getCaseNoteAnnotationsFromQueue()
 
     verify(jdaClient, times(3)).getCaseNoteAnnotationsFromQueue()
+    verify(caseNoteAnnotationsPersistenceService, times(2)).persistCaseNoteAnnotations(any())
   }
 
   @Test
-  fun `getCaseNoteAnnotationsFromQueue rethrows downstream failures`() {
+  fun `getCaseNoteAnnotationsFromQueue propagates downstream failures`() {
     whenever(jdaClient.getCaseNoteAnnotationsFromQueue())
       .thenThrow(
         DownstreamServiceException(
@@ -47,7 +52,30 @@ class CaseNoteAnnotationsServiceTest {
       service.getCaseNoteAnnotationsFromQueue()
     }
 
-    verify(jdaClient).getCaseNoteAnnotationsFromQueue()
+    verify(caseNoteAnnotationsPersistenceService, never()).persistCaseNoteAnnotations(any())
+  }
+
+  @Test
+  fun `getCaseNoteAnnotationsFromQueue continues draining when persisting an item fails`() {
+    val firstResponse = testResponse()
+    val secondResponse = testResponse()
+    val thirdResponse = testResponse()
+
+    whenever(jdaClient.getCaseNoteAnnotationsFromQueue())
+      .thenReturn(firstResponse)
+      .thenReturn(secondResponse)
+      .thenReturn(thirdResponse)
+      .thenReturn(null)
+
+    doThrow(RuntimeException("Something went wrong"))
+      .whenever(caseNoteAnnotationsPersistenceService).persistCaseNoteAnnotations(secondResponse)
+
+    service.getCaseNoteAnnotationsFromQueue()
+
+    verify(jdaClient, times(4)).getCaseNoteAnnotationsFromQueue()
+    verify(caseNoteAnnotationsPersistenceService).persistCaseNoteAnnotations(firstResponse)
+    verify(caseNoteAnnotationsPersistenceService).persistCaseNoteAnnotations(secondResponse)
+    verify(caseNoteAnnotationsPersistenceService).persistCaseNoteAnnotations(thirdResponse)
   }
 
   private fun testResponse() = JdaDequeueResponse(
@@ -60,7 +88,7 @@ class CaseNoteAnnotationsServiceTest {
     ),
     metadata = JdaDequeueResponseMetadata(
       requestType = JdaRequestType.ASYNC,
-      completedAt = Instant.now(),
+      completedAt = OffsetDateTime.now(),
       completionMs = 1200,
     ),
   )


### PR DESCRIPTION
[JDA-350](https://dsdmoj.atlassian.net/jira/software/c/projects/JDA/boards/15280?assignee=5cd29c554326200dc971eab7&selectedIssue=JDA-350)

1. implement new  cronjob to call JDA api every minute and fetch case note annotations from SQS queue
2. new controller endpoint for cronjob to call
3.  implement new service and outward api call to get case note annotations from JDA api

[JDA-350]: https://dsdmoj.atlassian.net/browse/JDA-350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ