### PR TITLE
JDA-494 Store Prompt values in config

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/client/casenotes/CaseNotesClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/client/casenotes/CaseNotesClient.kt
@@ -100,9 +100,14 @@ fun CaseNote.toCaseNoteAnalysisItem() = CaseNoteAnalysisItem(
 
 fun CaseNotesResponse.toJdaRequest(
   correlationId: String,
+  promptKey: String,
+  promptVersion: Int,
 ): JdaRequest<List<CaseNoteAnalysisItem>> = JdaRequest(
   correlationId = correlationId,
-  prompt = JdaPrompt.caseNoteAnalysis(),
+  prompt = JdaPrompt(
+    key = promptKey,
+    version = promptVersion,
+  ),
   requestData = content.map {
     it.toCaseNoteAnalysisItem()
   },

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaPrompt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/model/jda/JdaPrompt.kt
@@ -1,13 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.jda
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
 data class JdaPrompt(
   val key: String,
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
   val version: Int,
-) {
-  companion object {
-    fun caseNoteAnalysis() = JdaPrompt(
-      key = "case-note-analysis",
-      version = 3,
-    )
-  }
-}
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/JdaService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/JdaService.kt
@@ -12,6 +12,10 @@ class JdaService(
   private val caseNotesService: CaseNotesService,
   private val jdaClient: JdaClient,
   private val csipAssistConfig: CsipAssistConfig,
+  @Value("\${jda.prompt-key}")
+  private val promptKey: String,
+  @Value("\${jda.prompt-version:0}")
+  private val promptVersion: Int,
   @Value("\${feature.csip-assist}")
   private val featureFlag: Boolean,
 ) {
@@ -31,7 +35,7 @@ class JdaService(
       )
 
     jdaClient.submitRequest(
-      caseNotes.toJdaRequest(correlationId),
+      caseNotes.toJdaRequest(correlationId, promptKey, promptVersion),
     )
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -125,3 +125,7 @@ feature:
 csip:
   assist:
     active-prisons: "***"
+
+jda:
+  prompt-key: case-note-analysis
+  prompt-version: 0

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/client/casenotes/CaseNotesMappingsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/client/casenotes/CaseNotesMappingsTest.kt
@@ -148,18 +148,10 @@ class CaseNotesMappingsTest {
     val jsonVersion0 = jsonMapper.writerWithDefaultPrettyPrinter()
       .writeValueAsString(resultVersion0)
 
-    println("\n========== ACTUAL JSON WITH prompt-version = 0 ==========")
-    println(jsonVersion0)
-    println("========== END VERSION 0 ==========\n")
-
     // Version 3 - should include version field
     val resultVersion3 = response.toJdaRequest("referral-id", "case-note-analysis", 3)
     val jsonVersion3 = jsonMapper.writerWithDefaultPrettyPrinter()
       .writeValueAsString(resultVersion3)
-
-    println("========== ACTUAL JSON WITH prompt-version = 3 ==========")
-    println(jsonVersion3)
-    println("========== END VERSION 3 ==========\n")
 
     // Verify the assertions
     assertThat(jsonMapper.readTree(jsonVersion0)["prompt"].has("version")).isFalse()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/client/casenotes/CaseNotesMappingsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/client/casenotes/CaseNotesMappingsTest.kt
@@ -24,12 +24,12 @@ class CaseNotesMappingsTest {
   }
 
   @Test
-  fun `should create jda request`() {
+  fun `should create jda request with version 0`() {
     val caseNote = testCaseNote()
 
     val response = testCaseNotesResponse(caseNote)
 
-    val result = response.toJdaRequest("referral-id")
+    val result = response.toJdaRequest("referral-id", "case-note-analysis", 0)
 
     assertThat(result.correlationId)
       .isEqualTo("referral-id")
@@ -38,7 +38,7 @@ class CaseNotesMappingsTest {
       .isEqualTo("case-note-analysis")
 
     assertThat(result.prompt.version)
-      .isEqualTo(3)
+      .isEqualTo(0)
 
     val requestData = result.requestData
 
@@ -53,12 +53,24 @@ class CaseNotesMappingsTest {
   }
 
   @Test
-  fun `should serialize jda request using documented contract`() {
+  fun `should create jda request with version greater than 0`() {
     val caseNote = testCaseNote()
 
     val response = testCaseNotesResponse(caseNote)
 
-    val result = response.toJdaRequest("referral-id")
+    val result = response.toJdaRequest("referral-id", "case-note-analysis", 3)
+
+    assertThat(result.prompt.version)
+      .isEqualTo(3)
+  }
+
+  @Test
+  fun `should serialize jda request omitting version when 0`() {
+    val caseNote = testCaseNote()
+
+    val response = testCaseNotesResponse(caseNote)
+
+    val result = response.toJdaRequest("referral-id", "case-note-analysis", 0)
 
     val jsonNode = jsonMapper.readTree(
       jsonMapper.writeValueAsString(result),
@@ -70,8 +82,8 @@ class CaseNotesMappingsTest {
     assertThat(jsonNode["prompt"]["key"].asText())
       .isEqualTo("case-note-analysis")
 
-    assertThat(jsonNode["prompt"]["version"].asInt())
-      .isEqualTo(3)
+    assertThat(jsonNode["prompt"].has("version"))
+      .isFalse()
 
     assertThat(jsonNode["requestData"].isArray)
       .isTrue()
@@ -87,6 +99,71 @@ class CaseNotesMappingsTest {
 
     assertThat(jsonNode["requestData"][0].has("caseNotes"))
       .isFalse()
+  }
+
+  @Test
+  fun `should serialize jda request including version when greater than 0`() {
+    val caseNote = testCaseNote()
+
+    val response = testCaseNotesResponse(caseNote)
+
+    val result = response.toJdaRequest("referral-id", "case-note-analysis", 3)
+
+    val jsonNode = jsonMapper.readTree(
+      jsonMapper.writeValueAsString(result),
+    )
+
+    assertThat(jsonNode["correlationId"].asText())
+      .isEqualTo("referral-id")
+
+    assertThat(jsonNode["prompt"]["key"].asText())
+      .isEqualTo("case-note-analysis")
+
+    assertThat(jsonNode["prompt"].has("version"))
+      .isTrue()
+
+    assertThat(jsonNode["prompt"]["version"].asInt())
+      .isEqualTo(3)
+
+    assertThat(jsonNode["requestData"].isArray)
+      .isTrue()
+
+    assertThat(jsonNode["requestData"].size())
+      .isEqualTo(1)
+
+    assertThat(jsonNode["requestData"][0]["case_note_id"].asText())
+      .isEqualTo(caseNote.caseNoteId.toString())
+
+    assertThat(jsonNode["requestData"][0]["case_note_text"].asText())
+      .isEqualTo(caseNote.text)
+  }
+
+  @Test
+  fun `print actual json serialization for version 0 and version 3`() {
+    val caseNote = testCaseNote()
+    val response = testCaseNotesResponse(caseNote)
+
+    // Version 0 - should omit version field
+    val resultVersion0 = response.toJdaRequest("referral-id", "case-note-analysis", 0)
+    val jsonVersion0 = jsonMapper.writerWithDefaultPrettyPrinter()
+      .writeValueAsString(resultVersion0)
+
+    println("\n========== ACTUAL JSON WITH prompt-version = 0 ==========")
+    println(jsonVersion0)
+    println("========== END VERSION 0 ==========\n")
+
+    // Version 3 - should include version field
+    val resultVersion3 = response.toJdaRequest("referral-id", "case-note-analysis", 3)
+    val jsonVersion3 = jsonMapper.writerWithDefaultPrettyPrinter()
+      .writeValueAsString(resultVersion3)
+
+    println("========== ACTUAL JSON WITH prompt-version = 3 ==========")
+    println(jsonVersion3)
+    println("========== END VERSION 3 ==========\n")
+
+    // Verify the assertions
+    assertThat(jsonMapper.readTree(jsonVersion0)["prompt"].has("version")).isFalse()
+    assertThat(jsonMapper.readTree(jsonVersion3)["prompt"]["version"].asInt()).isEqualTo(3)
   }
 
   private fun testCaseNotesResponse(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/JdaServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/JdaServiceTest.kt
@@ -31,6 +31,8 @@ class JdaServiceTest {
       caseNotesService,
       jdaClient,
       csipAssistConfig,
+      "case-note-analysis",
+      0,
       true,
     )
 
@@ -39,6 +41,8 @@ class JdaServiceTest {
       caseNotesService,
       jdaClient,
       csipAssistConfig,
+      "case-note-analysis",
+      0,
       false,
     )
 
@@ -89,7 +93,7 @@ class JdaServiceTest {
       .isEqualTo("case-note-analysis")
 
     assertThat(requestCaptor.firstValue.prompt.version)
-      .isEqualTo(3)
+      .isEqualTo(0)
 
     assertThat(requestCaptor.firstValue.requestData)
       .hasSize(1)

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -52,3 +52,7 @@ hmpps.sqs:
 
 service:
   publish-events: true
+
+jda:
+  prompt-key: case-note-analysis
+  prompt-version: 0


### PR DESCRIPTION
Externalised JDA prompt configuration by moving prompt key and prompt version into application configuration.

Prompt version remains strongly typed as an integer. A configured value of 0 is treated as "no version" and is omitted from the outgoing JDA request JSON using Jackson conditional serialization.

This removes hardcoded prompt metadata while preserving compatibility with the JDA request contract.