### PR TITLE
JDA-497 Generate Annotated Case Notes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNotesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNotesService.kt
@@ -151,6 +151,55 @@ class CaseNotesService(
       }
   }
 
+  fun renderAnnotatedCaseNote(caseNoteWithAnnotations: CaseNoteWithAnnotations): String {
+    val originalText = caseNoteWithAnnotations.caseNote.text
+    if (caseNoteWithAnnotations.annotations.isEmpty()) return originalText
+
+    val matches = caseNoteWithAnnotations.annotations
+      .mapNotNull { it.annotatedText }
+      .filter { it.isNotBlank() }
+      .mapNotNull { annotationText ->
+        val startIndex = originalText.indexOf(annotationText)
+        if (startIndex < 0) return@mapNotNull null
+        TextMatch(start = startIndex, end = startIndex + annotationText.length, text = annotationText)
+      }
+      .sortedBy { it.start }
+
+    if (matches.isEmpty()) return originalText
+
+    val nonOverlappingMatches = mutableListOf<TextMatch>()
+    var currentEnd = -1
+
+    matches.forEach { match ->
+      if (match.start >= currentEnd) {
+        nonOverlappingMatches += match
+        currentEnd = match.end
+      }
+    }
+
+    if (nonOverlappingMatches.isEmpty()) return originalText
+
+    val renderedText = StringBuilder()
+    var cursor = 0
+
+    nonOverlappingMatches.forEach { match ->
+      renderedText.append(originalText.substring(cursor, match.start))
+      renderedText.append("<span class=\"annotation-type\">")
+      renderedText.append(match.text)
+      renderedText.append("</span>")
+      cursor = match.end
+    }
+
+    renderedText.append(originalText.substring(cursor))
+    return renderedText.toString()
+  }
+
+  private data class TextMatch(
+    val start: Int,
+    val end: Int,
+    val text: String,
+  )
+
   private fun CaseNoteAnnotation.toSummary() = CaseNoteAnnotationSummary(
     id = id,
     requestId = requestId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNotesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNotesService.kt
@@ -151,7 +151,7 @@ class CaseNotesService(
       }
   }
 
-  fun renderAnnotatedCaseNote(caseNoteWithAnnotations: CaseNoteWithAnnotations): String {
+  fun composeAnnotationCaseNote(caseNoteWithAnnotations: CaseNoteWithAnnotations): String {
     val originalText = caseNoteWithAnnotations.caseNote.text
     if (caseNoteWithAnnotations.annotations.isEmpty()) return originalText
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNotesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNotesServiceTest.kt
@@ -238,14 +238,14 @@ class CaseNotesServiceTest {
   }
 
   @Test
-  fun `renderAnnotatedCaseNote renders a single annotation`() {
+  fun `composeAnnotationCaseNote renders a single annotation`() {
     val originalText = "Prisoner became agitated and later raised his voice."
     val caseNoteWithAnnotations = caseNoteWithAnnotations(
       text = originalText,
       annotationTexts = listOf("became agitated"),
     )
 
-    val result = service.renderAnnotatedCaseNote(caseNoteWithAnnotations)
+    val result = service.composeAnnotationCaseNote(caseNoteWithAnnotations)
 
     assertThat(result).isEqualTo(
       "Prisoner <span class=\"annotation-type\">became agitated</span> and later raised his voice.",
@@ -253,14 +253,14 @@ class CaseNotesServiceTest {
   }
 
   @Test
-  fun `renderAnnotatedCaseNote renders multiple annotations`() {
+  fun `composeAnnotationCaseNote renders multiple annotations`() {
     val originalText = "Prisoner became agitated and later raised his voice."
     val caseNoteWithAnnotations = caseNoteWithAnnotations(
       text = originalText,
       annotationTexts = listOf("became agitated", "raised his voice"),
     )
 
-    val result = service.renderAnnotatedCaseNote(caseNoteWithAnnotations)
+    val result = service.composeAnnotationCaseNote(caseNoteWithAnnotations)
 
     assertThat(result).isEqualTo(
       "Prisoner <span class=\"annotation-type\">became agitated</span> and later <span class=\"annotation-type\">raised his voice</span>.",
@@ -268,27 +268,27 @@ class CaseNotesServiceTest {
   }
 
   @Test
-  fun `renderAnnotatedCaseNote returns original text when no annotations`() {
+  fun `composeAnnotationCaseNote returns original text when no annotations`() {
     val originalText = "Prisoner became agitated and later raised his voice."
     val caseNoteWithAnnotations = caseNoteWithAnnotations(
       text = originalText,
       annotationTexts = emptyList(),
     )
 
-    val result = service.renderAnnotatedCaseNote(caseNoteWithAnnotations)
+    val result = service.composeAnnotationCaseNote(caseNoteWithAnnotations)
 
     assertThat(result).isEqualTo(originalText)
   }
 
   @Test
-  fun `renderAnnotatedCaseNote ignores null annotation text`() {
+  fun `composeAnnotationCaseNote ignores null annotation text`() {
     val originalText = "Prisoner became agitated and later raised his voice."
     val caseNoteWithAnnotations = caseNoteWithAnnotations(
       text = originalText,
       annotationTexts = listOf(null, "raised his voice"),
     )
 
-    val result = service.renderAnnotatedCaseNote(caseNoteWithAnnotations)
+    val result = service.composeAnnotationCaseNote(caseNoteWithAnnotations)
 
     assertThat(result).isEqualTo(
       "Prisoner became agitated and later <span class=\"annotation-type\">raised his voice</span>.",
@@ -296,14 +296,14 @@ class CaseNotesServiceTest {
   }
 
   @Test
-  fun `renderAnnotatedCaseNote ignores blank annotation text`() {
+  fun `composeAnnotationCaseNote ignores blank annotation text`() {
     val originalText = "Prisoner became agitated and later raised his voice."
     val caseNoteWithAnnotations = caseNoteWithAnnotations(
       text = originalText,
       annotationTexts = listOf("   ", "raised his voice"),
     )
 
-    val result = service.renderAnnotatedCaseNote(caseNoteWithAnnotations)
+    val result = service.composeAnnotationCaseNote(caseNoteWithAnnotations)
 
     assertThat(result).isEqualTo(
       "Prisoner became agitated and later <span class=\"annotation-type\">raised his voice</span>.",
@@ -311,14 +311,14 @@ class CaseNotesServiceTest {
   }
 
   @Test
-  fun `renderAnnotatedCaseNote preserves original content outside annotations`() {
+  fun `composeAnnotationCaseNote preserves original content outside annotations`() {
     val originalText = "On review, prisoner became agitated, then settled down after staff support."
     val caseNoteWithAnnotations = caseNoteWithAnnotations(
       text = originalText,
       annotationTexts = listOf("became agitated"),
     )
 
-    val result = service.renderAnnotatedCaseNote(caseNoteWithAnnotations)
+    val result = service.composeAnnotationCaseNote(caseNoteWithAnnotations)
 
     assertThat(result).startsWith("On review, prisoner ")
     assertThat(result).contains("<span class=\"annotation-type\">became agitated</span>")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNotesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNotesServiceTest.kt
@@ -23,6 +23,8 @@ import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.enu
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.request.CaseNotesFilterParams
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.request.CaseNotesLookupRequest
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.request.SuggestedCaseNotesRequest
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.CaseNoteAnnotationSummary
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.CaseNoteWithAnnotations
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime
@@ -235,6 +237,94 @@ class CaseNotesServiceTest {
     verify(caseNotesClient, times(1)).getCaseNote("A1234AA", caseNoteIdTwo)
   }
 
+  @Test
+  fun `renderAnnotatedCaseNote renders a single annotation`() {
+    val originalText = "Prisoner became agitated and later raised his voice."
+    val caseNoteWithAnnotations = caseNoteWithAnnotations(
+      text = originalText,
+      annotationTexts = listOf("became agitated"),
+    )
+
+    val result = service.renderAnnotatedCaseNote(caseNoteWithAnnotations)
+
+    assertThat(result).isEqualTo(
+      "Prisoner <span class=\"annotation-type\">became agitated</span> and later raised his voice.",
+    )
+  }
+
+  @Test
+  fun `renderAnnotatedCaseNote renders multiple annotations`() {
+    val originalText = "Prisoner became agitated and later raised his voice."
+    val caseNoteWithAnnotations = caseNoteWithAnnotations(
+      text = originalText,
+      annotationTexts = listOf("became agitated", "raised his voice"),
+    )
+
+    val result = service.renderAnnotatedCaseNote(caseNoteWithAnnotations)
+
+    assertThat(result).isEqualTo(
+      "Prisoner <span class=\"annotation-type\">became agitated</span> and later <span class=\"annotation-type\">raised his voice</span>.",
+    )
+  }
+
+  @Test
+  fun `renderAnnotatedCaseNote returns original text when no annotations`() {
+    val originalText = "Prisoner became agitated and later raised his voice."
+    val caseNoteWithAnnotations = caseNoteWithAnnotations(
+      text = originalText,
+      annotationTexts = emptyList(),
+    )
+
+    val result = service.renderAnnotatedCaseNote(caseNoteWithAnnotations)
+
+    assertThat(result).isEqualTo(originalText)
+  }
+
+  @Test
+  fun `renderAnnotatedCaseNote ignores null annotation text`() {
+    val originalText = "Prisoner became agitated and later raised his voice."
+    val caseNoteWithAnnotations = caseNoteWithAnnotations(
+      text = originalText,
+      annotationTexts = listOf(null, "raised his voice"),
+    )
+
+    val result = service.renderAnnotatedCaseNote(caseNoteWithAnnotations)
+
+    assertThat(result).isEqualTo(
+      "Prisoner became agitated and later <span class=\"annotation-type\">raised his voice</span>.",
+    )
+  }
+
+  @Test
+  fun `renderAnnotatedCaseNote ignores blank annotation text`() {
+    val originalText = "Prisoner became agitated and later raised his voice."
+    val caseNoteWithAnnotations = caseNoteWithAnnotations(
+      text = originalText,
+      annotationTexts = listOf("   ", "raised his voice"),
+    )
+
+    val result = service.renderAnnotatedCaseNote(caseNoteWithAnnotations)
+
+    assertThat(result).isEqualTo(
+      "Prisoner became agitated and later <span class=\"annotation-type\">raised his voice</span>.",
+    )
+  }
+
+  @Test
+  fun `renderAnnotatedCaseNote preserves original content outside annotations`() {
+    val originalText = "On review, prisoner became agitated, then settled down after staff support."
+    val caseNoteWithAnnotations = caseNoteWithAnnotations(
+      text = originalText,
+      annotationTexts = listOf("became agitated"),
+    )
+
+    val result = service.renderAnnotatedCaseNote(caseNoteWithAnnotations)
+
+    assertThat(result).startsWith("On review, prisoner ")
+    assertThat(result).contains("<span class=\"annotation-type\">became agitated</span>")
+    assertThat(result).endsWith(", then settled down after staff support.")
+  }
+
   private fun annotation(
     caseNoteId: UUID?,
     annotatedText: String,
@@ -252,7 +342,7 @@ class CaseNotesServiceTest {
     createdDate = LocalDateTime.now(),
   )
 
-  private fun caseNote(caseNoteId: UUID) = CaseNote(
+  private fun caseNote(caseNoteId: UUID, text: String = "Case note text") = CaseNote(
     caseNoteId = caseNoteId,
     offenderIdentifier = "A1234AA",
     type = "GEN",
@@ -264,10 +354,35 @@ class CaseNotesServiceTest {
     authorName = "Test User",
     authorUserId = "USER1",
     authorUsername = "testuser",
-    text = "Case note text",
+    text = text,
     locationId = "MDI",
     sensitive = false,
     amendments = emptyList(),
+  )
+
+  private fun caseNoteWithAnnotations(
+    text: String,
+    annotationTexts: List<String?>,
+  ): CaseNoteWithAnnotations {
+    val caseNoteId = UUID.fromString("323e4567-e89b-12d3-a456-426614174000")
+
+    return CaseNoteWithAnnotations(
+      caseNote = caseNote(caseNoteId = caseNoteId, text = text),
+      annotations = annotationTexts.map { annotatedText -> annotationSummary(caseNoteId, annotatedText) },
+    )
+  }
+
+  private fun annotationSummary(caseNoteId: UUID, annotatedText: String?) = CaseNoteAnnotationSummary(
+    id = UUID.randomUUID(),
+    requestId = UUID.randomUUID(),
+    prisonerNumber = "A1234AA",
+    caseNoteId = caseNoteId,
+    promptKey = "case-note-analysis",
+    promptVersion = 3,
+    behaviourType = BehaviourType.RISKS_AND_TRIGGERS,
+    confidenceLevel = ConfidenceLevel.HIGH,
+    annotatedText = annotatedText,
+    createdDate = LocalDateTime.now(),
   )
 
   private fun prisonerDetails() = PrisonerDetails(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNotesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppschallengesupportinterventionplanapi/service/CaseNotesServiceTest.kt
@@ -20,11 +20,11 @@ import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.dom
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.domain.CaseNoteAnnotationRepository
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.enumeration.BehaviourType
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.enumeration.ConfidenceLevel
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.CaseNoteAnnotationSummary
+import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.CaseNoteWithAnnotations
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.request.CaseNotesFilterParams
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.request.CaseNotesLookupRequest
 import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.request.SuggestedCaseNotesRequest
-import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.CaseNoteAnnotationSummary
-import uk.gov.justice.digital.hmpps.hmppschallengesupportinterventionplanapi.model.CaseNoteWithAnnotations
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime


### PR DESCRIPTION
Annotation rendering assumes annotation text occurs uniquely within the case note, as confirmed by David. The renderer therefore highlights the first matching occurrence of each annotation string.